### PR TITLE
fix(verify): supplied expected_* measurement references hard-fail on mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ KDS, verify in WASM), build with `--target nodejs` and run
 ## Pinning launch measurements
 
 `VerifyParams` carries optional reference values that the verifier compares
-against the measurement registers in the quote. When the operator supplies a
-value, the corresponding `VerificationResult` field is `Some(true)`/`Some(false)`;
-when omitted the result is `None` (no check requested).
+against the measurement registers in the quote. A supplied value that doesn't
+match fails verification with `AttestationError::MeasurementMismatch` naming
+the register. On success the corresponding `VerificationResult` field is
+`Some(true)`; when omitted it is `None` (no check requested) — a returned
+result never carries `Some(false)`.
 
 ```rust
 use attestation::types::VerifyParams;
@@ -126,10 +128,10 @@ assert_eq!(result.rtmr1_match, Some(true));
 assert_eq!(result.rtmr2_match, Some(true));
 ```
 
-All comparisons are constant-time (`subtle::ConstantTimeEq`) and do not
-short-circuit — every populated reference is checked. `VerificationResult`
-carries `#[must_use]` so dropping the result without inspecting the policy
-outcomes is a compile-time warning.
+All comparisons are constant-time (`subtle::ConstantTimeEq`). Verification
+fails on the first mismatching register, so the error names one register even
+if several drift. Treat `Err` from `verify` as an attestation rejection, not
+a transient failure.
 
 The CLI exposes matching flags:
 

--- a/crates/attestation-cli/src/main.rs
+++ b/crates/attestation-cli/src/main.rs
@@ -467,17 +467,9 @@ async fn cmd_verify(args: VerifyArgs) {
     let json = serde_json::to_string_pretty(&result).expect("failed to serialize result");
     println!("{json}");
 
-    // Exit non-zero on signature failure or any explicit policy mismatch
-    // so CI/deploy gates fail closed when a pinned reference drifts.
-    let policy_failed = matches!(result.report_data_match, Some(false))
-        || matches!(result.init_data_match, Some(false))
-        || matches!(result.mrtd_match, Some(false))
-        || matches!(result.launch_digest_match, Some(false))
-        || matches!(result.rtmr0_match, Some(false))
-        || matches!(result.rtmr1_match, Some(false))
-        || matches!(result.rtmr2_match, Some(false))
-        || matches!(result.rtmr3_match, Some(false));
-    if !result.signature_valid || policy_failed {
+    // A supplied expected_* reference that mismatches fails verify() itself,
+    // so reaching this point means every pinned reference matched.
+    if !result.signature_valid {
         process::exit(1);
     }
 }

--- a/crates/attestation-wasm/src/lib.rs
+++ b/crates/attestation-wasm/src/lib.rs
@@ -321,9 +321,11 @@ async fn verify_tdx_impl(
         .await
         .map_err(|e| format!("tdx verify: {e}"))?;
 
-    // The core records the comparison without acting on it. Enforce here so a
-    // supplied pin cannot be a no-op. `None` means the core never performed the
-    // comparison at all — treat that as a failure, not an absence.
+    // The core now hard-fails a supplied pin on mismatch (MeasurementMismatch),
+    // so a mismatch never reaches this point. This gate stays as defense in
+    // depth: it guards a future core regression back to record-only semantics,
+    // and `None`-despite-a-pin (the core never performed the comparison) must
+    // still fail rather than read as absence.
     if rtmr3_pinned && result.rtmr3_match != Some(true) {
         return Err("tdx verify: RTMR[3] does not match expected_rtmr3 \
              (the guest was not launched with the pinned operator key, \
@@ -443,9 +445,13 @@ mod tests {
         let err = verify_tdx_impl(v5_evidence_json(), None, None, Some(vec![0xAA; 48]))
             .await
             .expect_err("wrong RTMR[3] pin must fail");
+        // The core's MeasurementMismatch names the register; the wrapper's own
+        // defense-in-depth gate names the parameter. Either way the register
+        // must be named — c8s-verify-js keys its rtmr3-denial classification
+        // on the "RTMR[3] does not match" prefix, so treat it as a contract.
         assert!(
-            err.contains("RTMR[3] does not match expected_rtmr3"),
-            "failure must name the pin, got: {err}"
+            err.contains("RTMR[3] does not match"),
+            "failure must name the register, got: {err}"
         );
     }
 

--- a/crates/attestation/src/error.rs
+++ b/crates/attestation/src/error.rs
@@ -48,6 +48,9 @@ pub enum AttestationError {
     #[error("init_data / host_data mismatch")]
     InitDataMismatch,
 
+    #[error("{0} does not match the supplied expected value")]
+    MeasurementMismatch(&'static str),
+
     #[error("guest launched with debug policy enabled")]
     DebugPolicyViolation,
 

--- a/crates/attestation/src/platforms/az_snp/verify.rs
+++ b/crates/attestation/src/platforms/az_snp/verify.rs
@@ -2,7 +2,7 @@ use crate::collateral::CertProvider;
 use crate::error::{AttestationError, Result};
 use crate::platforms::tpm_common;
 use crate::types::{PlatformType, ProcessorGeneration, VerificationResult, VerifyParams};
-use crate::utils::decode_base64url;
+use crate::utils::{check_expected, decode_base64url};
 
 use super::evidence::AzSnpEvidence;
 
@@ -212,12 +212,13 @@ pub fn verify_report(evidence: &AzSnpEvidence, params: &VerifyParams) -> Result<
         params.expected_init_data_hash.as_deref(),
     )?;
 
-    // Optional launch-digest compare. Mismatch surfaces in the result and
-    // does not fail verification.
-    let launch_digest_match = params
-        .expected_launch_digest
-        .as_ref()
-        .map(|expected| crate::utils::constant_time_eq(&snp_report.measurement[..], expected));
+    // Launch-digest check against a caller-supplied reference. Constant-time;
+    // a supplied reference that doesn't match fails verification.
+    let launch_digest_match = check_expected(
+        "launch digest",
+        &snp_report.measurement[..],
+        params.expected_launch_digest.as_ref().map(|e| e.as_slice()),
+    )?;
 
     let snp_claims = crate::platforms::snp::claims::extract_claims(&snp_report);
     let mut result = tpm_common::build_tpm_verification_result(

--- a/crates/attestation/src/platforms/az_snp/verify.rs
+++ b/crates/attestation/src/platforms/az_snp/verify.rs
@@ -1,5 +1,6 @@
 use crate::collateral::CertProvider;
 use crate::error::{AttestationError, Result};
+use crate::platforms::snp::verify::LAUNCH_DIGEST_LABEL;
 use crate::platforms::tpm_common;
 use crate::types::{PlatformType, ProcessorGeneration, VerificationResult, VerifyParams};
 use crate::utils::{check_expected, decode_base64url};
@@ -215,7 +216,7 @@ pub fn verify_report(evidence: &AzSnpEvidence, params: &VerifyParams) -> Result<
     // Launch-digest check against a caller-supplied reference. Constant-time;
     // a supplied reference that doesn't match fails verification.
     let launch_digest_match = check_expected(
-        "launch digest",
+        LAUNCH_DIGEST_LABEL,
         &snp_report.measurement[..],
         params.expected_launch_digest.as_ref().map(|e| e.as_slice()),
     )?;

--- a/crates/attestation/src/platforms/az_snp/verify.rs
+++ b/crates/attestation/src/platforms/az_snp/verify.rs
@@ -3,7 +3,7 @@ use crate::error::{AttestationError, Result};
 use crate::platforms::snp::verify::LAUNCH_DIGEST_LABEL;
 use crate::platforms::tpm_common;
 use crate::types::{PlatformType, ProcessorGeneration, VerificationResult, VerifyParams};
-use crate::utils::{check_expected, decode_base64url};
+use crate::utils::{check_expected_measurements_match, decode_base64url};
 
 use super::evidence::AzSnpEvidence;
 
@@ -215,7 +215,7 @@ pub fn verify_report(evidence: &AzSnpEvidence, params: &VerifyParams) -> Result<
 
     // Launch-digest check against a caller-supplied reference. Constant-time;
     // a supplied reference that doesn't match fails verification.
-    let launch_digest_match = check_expected(
+    let launch_digest_match = check_expected_measurements_match(
         LAUNCH_DIGEST_LABEL,
         &snp_report.measurement[..],
         params.expected_launch_digest.as_ref().map(|e| e.as_slice()),

--- a/crates/attestation/src/platforms/az_tdx/verify.rs
+++ b/crates/attestation/src/platforms/az_tdx/verify.rs
@@ -3,7 +3,7 @@ use crate::error::{AttestationError, Result};
 use crate::platforms::tdx::{claims::extract_claims, dcap, verify as tdx_verify};
 use crate::platforms::tpm_common;
 use crate::types::{PlatformType, VerificationResult, VerifyParams};
-use crate::utils::{check_expected, decode_base64url};
+use crate::utils::decode_base64url;
 
 use super::evidence::AzTdxEvidence;
 
@@ -128,33 +128,7 @@ pub async fn verify_evidence(
         params.expected_init_data_hash.as_deref(),
     )?;
 
-    // MRTD / RTMR checks against caller-supplied references. Constant-time;
-    // a supplied reference that doesn't match fails verification.
-    let mrtd_match = check_expected(
-        "MRTD",
-        &tdx_quote.body.mr_td,
-        params.expected_mrtd.as_ref().map(|e| e.as_slice()),
-    )?;
-    let rtmr0_match = check_expected(
-        "RTMR[0]",
-        &tdx_quote.body.rtmr_0,
-        params.expected_rtmr0.as_ref().map(|e| e.as_slice()),
-    )?;
-    let rtmr1_match = check_expected(
-        "RTMR[1]",
-        &tdx_quote.body.rtmr_1,
-        params.expected_rtmr1.as_ref().map(|e| e.as_slice()),
-    )?;
-    let rtmr2_match = check_expected(
-        "RTMR[2]",
-        &tdx_quote.body.rtmr_2,
-        params.expected_rtmr2.as_ref().map(|e| e.as_slice()),
-    )?;
-    let rtmr3_match = check_expected(
-        "RTMR[3]",
-        &tdx_quote.body.rtmr_3,
-        params.expected_rtmr3.as_ref().map(|e| e.as_slice()),
-    )?;
+    let matches = tdx_verify::check_expected_measurements(&tdx_quote.body, params)?;
 
     // Result
     let tdx_claims = extract_claims(&tdx_quote);
@@ -169,11 +143,11 @@ pub async fn verify_evidence(
         collateral_verified,
     );
     result.tcb_status = tcb_status;
-    result.mrtd_match = mrtd_match;
-    result.rtmr0_match = rtmr0_match;
-    result.rtmr1_match = rtmr1_match;
-    result.rtmr2_match = rtmr2_match;
-    result.rtmr3_match = rtmr3_match;
+    result.mrtd_match = matches.mrtd;
+    result.rtmr0_match = matches.rtmr0;
+    result.rtmr1_match = matches.rtmr1;
+    result.rtmr2_match = matches.rtmr2;
+    result.rtmr3_match = matches.rtmr3;
     Ok(result)
 }
 

--- a/crates/attestation/src/platforms/az_tdx/verify.rs
+++ b/crates/attestation/src/platforms/az_tdx/verify.rs
@@ -3,7 +3,7 @@ use crate::error::{AttestationError, Result};
 use crate::platforms::tdx::{claims::extract_claims, dcap, verify as tdx_verify};
 use crate::platforms::tpm_common;
 use crate::types::{PlatformType, VerificationResult, VerifyParams};
-use crate::utils::decode_base64url;
+use crate::utils::{check_expected, decode_base64url};
 
 use super::evidence::AzTdxEvidence;
 
@@ -128,28 +128,33 @@ pub async fn verify_evidence(
         params.expected_init_data_hash.as_deref(),
     )?;
 
-    // Optional MRTD / RTMR compares. Mismatches surface in the result and
-    // do not fail verification.
-    let mrtd_match = params
-        .expected_mrtd
-        .as_ref()
-        .map(|expected| crate::utils::constant_time_eq(&tdx_quote.body.mr_td, expected));
-    let rtmr0_match = params
-        .expected_rtmr0
-        .as_ref()
-        .map(|expected| crate::utils::constant_time_eq(&tdx_quote.body.rtmr_0, expected));
-    let rtmr1_match = params
-        .expected_rtmr1
-        .as_ref()
-        .map(|expected| crate::utils::constant_time_eq(&tdx_quote.body.rtmr_1, expected));
-    let rtmr2_match = params
-        .expected_rtmr2
-        .as_ref()
-        .map(|expected| crate::utils::constant_time_eq(&tdx_quote.body.rtmr_2, expected));
-    let rtmr3_match = params
-        .expected_rtmr3
-        .as_ref()
-        .map(|expected| crate::utils::constant_time_eq(&tdx_quote.body.rtmr_3, expected));
+    // MRTD / RTMR checks against caller-supplied references. Constant-time;
+    // a supplied reference that doesn't match fails verification.
+    let mrtd_match = check_expected(
+        "MRTD",
+        &tdx_quote.body.mr_td,
+        params.expected_mrtd.as_ref().map(|e| e.as_slice()),
+    )?;
+    let rtmr0_match = check_expected(
+        "RTMR[0]",
+        &tdx_quote.body.rtmr_0,
+        params.expected_rtmr0.as_ref().map(|e| e.as_slice()),
+    )?;
+    let rtmr1_match = check_expected(
+        "RTMR[1]",
+        &tdx_quote.body.rtmr_1,
+        params.expected_rtmr1.as_ref().map(|e| e.as_slice()),
+    )?;
+    let rtmr2_match = check_expected(
+        "RTMR[2]",
+        &tdx_quote.body.rtmr_2,
+        params.expected_rtmr2.as_ref().map(|e| e.as_slice()),
+    )?;
+    let rtmr3_match = check_expected(
+        "RTMR[3]",
+        &tdx_quote.body.rtmr_3,
+        params.expected_rtmr3.as_ref().map(|e| e.as_slice()),
+    )?;
 
     // Result
     let tdx_claims = extract_claims(&tdx_quote);

--- a/crates/attestation/src/platforms/az_tdx/verify.rs
+++ b/crates/attestation/src/platforms/az_tdx/verify.rs
@@ -128,7 +128,7 @@ pub async fn verify_evidence(
         params.expected_init_data_hash.as_deref(),
     )?;
 
-    let matches = tdx_verify::check_expected_measurements(&tdx_quote.body, params)?;
+    let register_match_checks = tdx_verify::check_expected_measurements(&tdx_quote.body, params)?;
 
     // Result
     let tdx_claims = extract_claims(&tdx_quote);
@@ -143,11 +143,11 @@ pub async fn verify_evidence(
         collateral_verified,
     );
     result.tcb_status = tcb_status;
-    result.mrtd_match = matches.mrtd;
-    result.rtmr0_match = matches.rtmr0;
-    result.rtmr1_match = matches.rtmr1;
-    result.rtmr2_match = matches.rtmr2;
-    result.rtmr3_match = matches.rtmr3;
+    result.mrtd_match = register_match_checks.mrtd;
+    result.rtmr0_match = register_match_checks.rtmr0;
+    result.rtmr1_match = register_match_checks.rtmr1;
+    result.rtmr2_match = register_match_checks.rtmr2;
+    result.rtmr3_match = register_match_checks.rtmr3;
     Ok(result)
 }
 

--- a/crates/attestation/src/platforms/gcp_snp/verify.rs
+++ b/crates/attestation/src/platforms/gcp_snp/verify.rs
@@ -113,18 +113,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_gcp_snp_propagates_wrong_launch_digest() {
+    async fn test_gcp_snp_wrong_launch_digest_fails() {
         let evidence = make_snp_evidence(LIVE_REPORT_V5, LIVE_VCEK_GENOA);
         let params = VerifyParams {
             expected_launch_digest: Some([0x77; 48]),
             ..Default::default()
         };
-        let r = verify_evidence(&evidence, &params, &StubCertProvider)
+        let err = verify_evidence(&evidence, &params, &StubCertProvider)
             .await
-            .unwrap();
-        assert_eq!(r.platform, PlatformType::GcpSnp);
-        assert_eq!(r.launch_digest_match, Some(false));
-        // Even with wrong digest, signature still valid — policy decision in caller
-        assert!(r.signature_valid);
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::AttestationError::MeasurementMismatch("launch digest")
+        ));
     }
 }

--- a/crates/attestation/src/platforms/gcp_tdx/verify.rs
+++ b/crates/attestation/src/platforms/gcp_tdx/verify.rs
@@ -78,15 +78,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_gcp_tdx_propagates_wrong_mrtd_match() {
+    async fn test_gcp_tdx_wrong_mrtd_fails() {
         let evidence = make_tdx_evidence(V4_QUOTE);
         let params = VerifyParams {
             allow_debug: true,
             expected_mrtd: Some([0x55; 48]),
             ..Default::default()
         };
-        let r = verify_evidence(&evidence, &params, None).await.unwrap();
-        assert_eq!(r.platform, PlatformType::GcpTdx);
-        assert_eq!(r.mrtd_match, Some(false));
+        let err = verify_evidence(&evidence, &params, None).await.unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::AttestationError::MeasurementMismatch("MRTD")
+        ));
     }
 }

--- a/crates/attestation/src/platforms/snp/verify.rs
+++ b/crates/attestation/src/platforms/snp/verify.rs
@@ -30,6 +30,10 @@ const MIN_REPORT_VERSION: u32 = 3;
 /// Matches Trustee's upper bound — future versions may change field layout.
 pub const MAX_REPORT_VERSION: u32 = 5;
 
+/// Register label carried by `MeasurementMismatch` for the SNP launch
+/// digest; shared with the Azure vTPM SNP path.
+pub(crate) const LAUNCH_DIGEST_LABEL: &str = "launch digest";
+
 /// Verify SNP attestation evidence.
 pub async fn verify_evidence(
     evidence: &SnpEvidence,
@@ -161,7 +165,7 @@ pub async fn verify_evidence(
     // Launch-digest check against a caller-supplied reference. Constant-time;
     // a supplied reference that doesn't match fails verification.
     let launch_digest_match = check_expected(
-        "launch digest",
+        LAUNCH_DIGEST_LABEL,
         &report.measurement[..],
         params.expected_launch_digest.as_ref().map(|e| e.as_slice()),
     )?;
@@ -1081,6 +1085,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(r.launch_digest_match, Some(true));
+        // Pins that signature verification still runs and precedes the
+        // reference checks when expected_* values are supplied.
+        assert!(r.signature_valid);
     }
 
     #[tokio::test]

--- a/crates/attestation/src/platforms/snp/verify.rs
+++ b/crates/attestation/src/platforms/snp/verify.rs
@@ -11,6 +11,7 @@ use sev::parser::ByteParser;
 use crate::collateral::CertProvider;
 use crate::error::{AttestationError, Result};
 use crate::types::{PlatformType, ProcessorGeneration, SnpTcb, VerificationResult, VerifyParams};
+use crate::utils::check_expected;
 
 // OID constants for CRL signature algorithm identification.
 // x509-parser's verify_signature does not support OID_RSA_PSS (rsaPSS with parameters),
@@ -157,12 +158,13 @@ pub async fn verify_evidence(
         None
     };
 
-    // Optional launch-digest compare. Mismatch surfaces in the result and
-    // does not fail verification.
-    let launch_digest_match = params
-        .expected_launch_digest
-        .as_ref()
-        .map(|expected| crate::utils::constant_time_eq(&report.measurement[..], expected));
+    // Launch-digest check against a caller-supplied reference. Constant-time;
+    // a supplied reference that doesn't match fails verification.
+    let launch_digest_match = check_expected(
+        "launch digest",
+        &report.measurement[..],
+        params.expected_launch_digest.as_ref().map(|e| e.as_slice()),
+    )?;
 
     // 11. Extract claims
     let claims = extract_claims(&report);
@@ -1082,18 +1084,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_verify_evidence_wrong_launch_digest_is_some_false() {
-        // Wrong digest must record Some(false) without failing verification.
+    async fn test_verify_evidence_wrong_launch_digest_fails() {
         let evidence = make_snp_evidence_with_vcek(LIVE_REPORT_V5, LIVE_VCEK_GENOA);
         let provider = StubCertProvider;
         let params = VerifyParams {
             expected_launch_digest: Some([0xAA; 48]),
             ..Default::default()
         };
-        let r = verify_evidence(&evidence, &params, &provider)
+        let err = verify_evidence(&evidence, &params, &provider)
             .await
-            .unwrap();
-        assert_eq!(r.launch_digest_match, Some(false));
-        assert!(r.signature_valid, "wrong digest should NOT fail signature");
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            AttestationError::MeasurementMismatch("launch digest")
+        ));
     }
 }

--- a/crates/attestation/src/platforms/snp/verify.rs
+++ b/crates/attestation/src/platforms/snp/verify.rs
@@ -11,7 +11,7 @@ use sev::parser::ByteParser;
 use crate::collateral::CertProvider;
 use crate::error::{AttestationError, Result};
 use crate::types::{PlatformType, ProcessorGeneration, SnpTcb, VerificationResult, VerifyParams};
-use crate::utils::check_expected;
+use crate::utils::check_expected_measurements_match;
 
 // OID constants for CRL signature algorithm identification.
 // x509-parser's verify_signature does not support OID_RSA_PSS (rsaPSS with parameters),
@@ -164,7 +164,7 @@ pub async fn verify_evidence(
 
     // Launch-digest check against a caller-supplied reference. Constant-time;
     // a supplied reference that doesn't match fails verification.
-    let launch_digest_match = check_expected(
+    let launch_digest_match = check_expected_measurements_match(
         LAUNCH_DIGEST_LABEL,
         &report.measurement[..],
         params.expected_launch_digest.as_ref().map(|e| e.as_slice()),

--- a/crates/attestation/src/platforms/tdx/verify.rs
+++ b/crates/attestation/src/platforms/tdx/verify.rs
@@ -442,33 +442,7 @@ pub async fn verify_evidence(
         None
     };
 
-    // MRTD / RTMR checks against caller-supplied references. Constant-time;
-    // a supplied reference that doesn't match fails verification.
-    let mrtd_match = check_expected(
-        "MRTD",
-        &quote.body.mr_td,
-        params.expected_mrtd.as_ref().map(|e| e.as_slice()),
-    )?;
-    let rtmr0_match = check_expected(
-        "RTMR[0]",
-        &quote.body.rtmr_0,
-        params.expected_rtmr0.as_ref().map(|e| e.as_slice()),
-    )?;
-    let rtmr1_match = check_expected(
-        "RTMR[1]",
-        &quote.body.rtmr_1,
-        params.expected_rtmr1.as_ref().map(|e| e.as_slice()),
-    )?;
-    let rtmr2_match = check_expected(
-        "RTMR[2]",
-        &quote.body.rtmr_2,
-        params.expected_rtmr2.as_ref().map(|e| e.as_slice()),
-    )?;
-    let rtmr3_match = check_expected(
-        "RTMR[3]",
-        &quote.body.rtmr_3,
-        params.expected_rtmr3.as_ref().map(|e| e.as_slice()),
-    )?;
+    let matches = check_expected_measurements(&quote.body, params)?;
 
     // 6. Eventlog integrity check (if present)
     if let Some(ref eventlog_b64) = evidence.cc_eventlog {
@@ -496,12 +470,58 @@ pub async fn verify_evidence(
         init_data_match,
         collateral_verified: tcb_status.is_some(),
         tcb_status,
-        mrtd_match,
-        rtmr0_match,
-        rtmr1_match,
-        rtmr2_match,
-        rtmr3_match,
+        mrtd_match: matches.mrtd,
+        rtmr0_match: matches.rtmr0,
+        rtmr1_match: matches.rtmr1,
+        rtmr2_match: matches.rtmr2,
+        rtmr3_match: matches.rtmr3,
         launch_digest_match: None,
+    })
+}
+
+/// Per-register results of [`check_expected_measurements`]; semantics match
+/// the corresponding `*_match` fields on [`VerificationResult`].
+pub(crate) struct MeasurementMatches {
+    pub mrtd: Option<bool>,
+    pub rtmr0: Option<bool>,
+    pub rtmr1: Option<bool>,
+    pub rtmr2: Option<bool>,
+    pub rtmr3: Option<bool>,
+}
+
+/// Check a TDX report body against the caller-supplied MRTD / RTMR
+/// references. Constant-time; a supplied reference that doesn't match fails
+/// verification. Shared by the bare-metal and Azure vTPM TDX paths.
+pub(crate) fn check_expected_measurements(
+    body: &TdxReportBody,
+    params: &VerifyParams,
+) -> Result<MeasurementMatches> {
+    Ok(MeasurementMatches {
+        mrtd: check_expected(
+            "MRTD",
+            &body.mr_td,
+            params.expected_mrtd.as_ref().map(|e| e.as_slice()),
+        )?,
+        rtmr0: check_expected(
+            "RTMR[0]",
+            &body.rtmr_0,
+            params.expected_rtmr0.as_ref().map(|e| e.as_slice()),
+        )?,
+        rtmr1: check_expected(
+            "RTMR[1]",
+            &body.rtmr_1,
+            params.expected_rtmr1.as_ref().map(|e| e.as_slice()),
+        )?,
+        rtmr2: check_expected(
+            "RTMR[2]",
+            &body.rtmr_2,
+            params.expected_rtmr2.as_ref().map(|e| e.as_slice()),
+        )?,
+        rtmr3: check_expected(
+            "RTMR[3]",
+            &body.rtmr_3,
+            params.expected_rtmr3.as_ref().map(|e| e.as_slice()),
+        )?,
     })
 }
 

--- a/crates/attestation/src/platforms/tdx/verify.rs
+++ b/crates/attestation/src/platforms/tdx/verify.rs
@@ -1071,6 +1071,9 @@ mod tests {
         };
         let r = verify_evidence(&evidence, &params, None).await.unwrap();
         assert_eq!(r.mrtd_match, Some(true));
+        // Pins that signature verification still runs and precedes the
+        // reference checks when expected_* values are supplied.
+        assert!(r.signature_valid);
     }
 
     #[tokio::test]
@@ -1109,8 +1112,8 @@ mod tests {
         let params = VerifyParams {
             allow_debug: true,
             expected_rtmr0: Some(quote.body.rtmr_0), // match
-            expected_rtmr1: Some([0xFF; 48]),        // mismatch
-            expected_rtmr3: Some(quote.body.rtmr_3), // match (rtmr2 left None → skipped)
+            expected_rtmr1: Some([0xFF; 48]),        // first mismatch — fails here
+            expected_rtmr3: Some(quote.body.rtmr_3), // supplied but never reached
             ..Default::default()
         };
         let err = verify_evidence(&evidence, &params, None).await.unwrap_err();

--- a/crates/attestation/src/platforms/tdx/verify.rs
+++ b/crates/attestation/src/platforms/tdx/verify.rs
@@ -6,6 +6,7 @@ use scroll::Pread;
 use crate::collateral::TdxCollateralProvider;
 use crate::error::{AttestationError, Result};
 use crate::types::{PlatformType, VerificationResult, VerifyParams};
+use crate::utils::check_expected;
 
 use super::claims::extract_claims;
 use super::evidence::TdxEvidence;
@@ -441,28 +442,33 @@ pub async fn verify_evidence(
         None
     };
 
-    // Optional MRTD / RTMR comparisons against caller-supplied references.
-    // Constant-time; mismatch surfaces in the result and does not fail verify.
-    let mrtd_match = params
-        .expected_mrtd
-        .as_ref()
-        .map(|expected| crate::utils::constant_time_eq(&quote.body.mr_td, expected));
-    let rtmr0_match = params
-        .expected_rtmr0
-        .as_ref()
-        .map(|expected| crate::utils::constant_time_eq(&quote.body.rtmr_0, expected));
-    let rtmr1_match = params
-        .expected_rtmr1
-        .as_ref()
-        .map(|expected| crate::utils::constant_time_eq(&quote.body.rtmr_1, expected));
-    let rtmr2_match = params
-        .expected_rtmr2
-        .as_ref()
-        .map(|expected| crate::utils::constant_time_eq(&quote.body.rtmr_2, expected));
-    let rtmr3_match = params
-        .expected_rtmr3
-        .as_ref()
-        .map(|expected| crate::utils::constant_time_eq(&quote.body.rtmr_3, expected));
+    // MRTD / RTMR checks against caller-supplied references. Constant-time;
+    // a supplied reference that doesn't match fails verification.
+    let mrtd_match = check_expected(
+        "MRTD",
+        &quote.body.mr_td,
+        params.expected_mrtd.as_ref().map(|e| e.as_slice()),
+    )?;
+    let rtmr0_match = check_expected(
+        "RTMR[0]",
+        &quote.body.rtmr_0,
+        params.expected_rtmr0.as_ref().map(|e| e.as_slice()),
+    )?;
+    let rtmr1_match = check_expected(
+        "RTMR[1]",
+        &quote.body.rtmr_1,
+        params.expected_rtmr1.as_ref().map(|e| e.as_slice()),
+    )?;
+    let rtmr2_match = check_expected(
+        "RTMR[2]",
+        &quote.body.rtmr_2,
+        params.expected_rtmr2.as_ref().map(|e| e.as_slice()),
+    )?;
+    let rtmr3_match = check_expected(
+        "RTMR[3]",
+        &quote.body.rtmr_3,
+        params.expected_rtmr3.as_ref().map(|e| e.as_slice()),
+    )?;
 
     // 6. Eventlog integrity check (if present)
     if let Some(ref eventlog_b64) = evidence.cc_eventlog {
@@ -1048,18 +1054,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_verify_evidence_wrong_mrtd_is_some_false() {
-        // Wrong MRTD must record Some(false) without failing verification.
+    async fn test_verify_evidence_wrong_mrtd_fails() {
         let evidence = make_tdx_evidence(V4_QUOTE);
         let params = VerifyParams {
             allow_debug: true,
             expected_mrtd: Some([0xAA; 48]),
             ..Default::default()
         };
-        let r = verify_evidence(&evidence, &params, None).await.unwrap();
-        assert_eq!(r.mrtd_match, Some(false));
-        // Crucially the rest of the result is still populated — sig is valid.
-        assert!(r.signature_valid);
+        let err = verify_evidence(&evidence, &params, None).await.unwrap_err();
+        assert!(matches!(err, AttestationError::MeasurementMismatch("MRTD")));
     }
 
     #[tokio::test]
@@ -1080,7 +1083,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_verify_evidence_mixed_rtmr_match_and_mismatch() {
+    async fn test_verify_evidence_one_wrong_rtmr_fails() {
         let quote = parse_tdx_quote(V4_QUOTE).unwrap();
         let evidence = make_tdx_evidence(V4_QUOTE);
         let params = VerifyParams {
@@ -1090,10 +1093,10 @@ mod tests {
             expected_rtmr3: Some(quote.body.rtmr_3), // match (rtmr2 left None → skipped)
             ..Default::default()
         };
-        let r = verify_evidence(&evidence, &params, None).await.unwrap();
-        assert_eq!(r.rtmr0_match, Some(true));
-        assert_eq!(r.rtmr1_match, Some(false));
-        assert_eq!(r.rtmr2_match, None);
-        assert_eq!(r.rtmr3_match, Some(true));
+        let err = verify_evidence(&evidence, &params, None).await.unwrap_err();
+        assert!(matches!(
+            err,
+            AttestationError::MeasurementMismatch("RTMR[1]")
+        ));
     }
 }

--- a/crates/attestation/src/platforms/tdx/verify.rs
+++ b/crates/attestation/src/platforms/tdx/verify.rs
@@ -6,7 +6,7 @@ use scroll::Pread;
 use crate::collateral::TdxCollateralProvider;
 use crate::error::{AttestationError, Result};
 use crate::types::{PlatformType, VerificationResult, VerifyParams};
-use crate::utils::check_expected;
+use crate::utils::check_expected_measurements_match;
 
 use super::claims::extract_claims;
 use super::evidence::TdxEvidence;
@@ -442,7 +442,7 @@ pub async fn verify_evidence(
         None
     };
 
-    let matches = check_expected_measurements(&quote.body, params)?;
+    let register_match_checks = check_expected_measurements(&quote.body, params)?;
 
     // 6. Eventlog integrity check (if present)
     if let Some(ref eventlog_b64) = evidence.cc_eventlog {
@@ -470,11 +470,11 @@ pub async fn verify_evidence(
         init_data_match,
         collateral_verified: tcb_status.is_some(),
         tcb_status,
-        mrtd_match: matches.mrtd,
-        rtmr0_match: matches.rtmr0,
-        rtmr1_match: matches.rtmr1,
-        rtmr2_match: matches.rtmr2,
-        rtmr3_match: matches.rtmr3,
+        mrtd_match: register_match_checks.mrtd,
+        rtmr0_match: register_match_checks.rtmr0,
+        rtmr1_match: register_match_checks.rtmr1,
+        rtmr2_match: register_match_checks.rtmr2,
+        rtmr3_match: register_match_checks.rtmr3,
         launch_digest_match: None,
     })
 }
@@ -497,27 +497,27 @@ pub(crate) fn check_expected_measurements(
     params: &VerifyParams,
 ) -> Result<MeasurementMatches> {
     Ok(MeasurementMatches {
-        mrtd: check_expected(
+        mrtd: check_expected_measurements_match(
             "MRTD",
             &body.mr_td,
             params.expected_mrtd.as_ref().map(|e| e.as_slice()),
         )?,
-        rtmr0: check_expected(
+        rtmr0: check_expected_measurements_match(
             "RTMR[0]",
             &body.rtmr_0,
             params.expected_rtmr0.as_ref().map(|e| e.as_slice()),
         )?,
-        rtmr1: check_expected(
+        rtmr1: check_expected_measurements_match(
             "RTMR[1]",
             &body.rtmr_1,
             params.expected_rtmr1.as_ref().map(|e| e.as_slice()),
         )?,
-        rtmr2: check_expected(
+        rtmr2: check_expected_measurements_match(
             "RTMR[2]",
             &body.rtmr_2,
             params.expected_rtmr2.as_ref().map(|e| e.as_slice()),
         )?,
-        rtmr3: check_expected(
+        rtmr3: check_expected_measurements_match(
             "RTMR[3]",
             &body.rtmr_3,
             params.expected_rtmr3.as_ref().map(|e| e.as_slice()),

--- a/crates/attestation/src/types.rs
+++ b/crates/attestation/src/types.rs
@@ -82,21 +82,21 @@ pub struct VerifyParams {
     pub allow_debug: bool,
     /// If set, enforce minimum TCB version for SNP (each component must be >=).
     pub min_tcb: Option<SnpTcb>,
-    /// Expected MRTD. Result surfaces in [`VerificationResult::mrtd_match`];
-    /// mismatch does not fail verification. TDX-only.
+    /// Expected MRTD. Mismatch fails verification with
+    /// [`AttestationError::MeasurementMismatch`]; a match surfaces as
+    /// `Some(true)` in [`VerificationResult::mrtd_match`]. TDX-only.
     pub expected_mrtd: Option<[u8; 48]>,
-    /// Expected RTMR[0]. Result in [`VerificationResult::rtmr0_match`]; mismatch
-    /// does not fail verification. TDX-only.
+    /// Expected RTMR[0]. Mismatch fails verification. TDX-only.
     pub expected_rtmr0: Option<[u8; 48]>,
-    /// Expected RTMR[1]. TDX-only.
+    /// Expected RTMR[1]. Mismatch fails verification. TDX-only.
     pub expected_rtmr1: Option<[u8; 48]>,
-    /// Expected RTMR[2]. TDX-only.
+    /// Expected RTMR[2]. Mismatch fails verification. TDX-only.
     pub expected_rtmr2: Option<[u8; 48]>,
-    /// Expected RTMR[3]. TDX-only.
+    /// Expected RTMR[3]. Mismatch fails verification. TDX-only.
     pub expected_rtmr3: Option<[u8; 48]>,
-    /// Expected SNP launch digest (`report.measurement`). Result in
-    /// [`VerificationResult::launch_digest_match`]; mismatch does not fail
-    /// verification. SNP-only.
+    /// Expected SNP launch digest (`report.measurement`). Mismatch fails
+    /// verification; a match surfaces as `Some(true)` in
+    /// [`VerificationResult::launch_digest_match`]. SNP-only.
     pub expected_launch_digest: Option<[u8; 48]>,
     /// NVIDIA GPU verification parameters, applied when an envelope carries a
     /// `gpu` bundle. Grouped behind a single feature gate (see
@@ -195,11 +195,13 @@ pub struct VerificationResult {
     /// Platform-specific collateral/TCB status details (TDX DCAP status, etc.).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tcb_status: Option<DcapVerificationStatus>,
-    /// MRTD compare result. `None` if no expected value was supplied.
-    /// Always `None` for SNP.
+    /// MRTD compare result: `Some(true)` when an expected value was supplied
+    /// (a mismatch fails verification, so `Some(false)` never appears in a
+    /// returned result), `None` when not supplied. Always `None` for SNP.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mrtd_match: Option<bool>,
-    /// RTMR[0] compare result. Always `None` for SNP.
+    /// RTMR[0] compare result; same semantics as `mrtd_match`. Always `None`
+    /// for SNP.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rtmr0_match: Option<bool>,
     /// RTMR[1] compare result. Always `None` for SNP.
@@ -211,8 +213,8 @@ pub struct VerificationResult {
     /// RTMR[3] compare result. Always `None` for SNP.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rtmr3_match: Option<bool>,
-    /// SNP launch digest compare result. `None` if no expected value was
-    /// supplied. Always `None` for TDX.
+    /// SNP launch digest compare result; same semantics as `mrtd_match`.
+    /// Always `None` for TDX.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub launch_digest_match: Option<bool>,
 }

--- a/crates/attestation/src/utils.rs
+++ b/crates/attestation/src/utils.rs
@@ -96,6 +96,22 @@ pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     a.ct_eq(b).into()
 }
 
+/// Check a measurement register against an optional caller-supplied
+/// reference value. Not supplied → `Ok(None)`; supplied and equal →
+/// `Ok(Some(true))`; supplied and different → `MeasurementMismatch`,
+/// failing verification. `Some(false)` is never produced.
+pub(crate) fn check_expected(
+    name: &'static str,
+    actual: &[u8],
+    expected: Option<&[u8]>,
+) -> crate::error::Result<Option<bool>> {
+    match expected {
+        None => Ok(None),
+        Some(expected) if constant_time_eq(actual, expected) => Ok(Some(true)),
+        Some(_) => Err(crate::error::AttestationError::MeasurementMismatch(name)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/attestation/src/utils.rs
+++ b/crates/attestation/src/utils.rs
@@ -100,6 +100,11 @@ pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 /// reference value. Not supplied → `Ok(None)`; supplied and equal →
 /// `Ok(Some(true))`; supplied and different → `MeasurementMismatch`,
 /// failing verification. `Some(false)` is never produced.
+///
+/// Gated on the platform features that consume it: an embedder building only
+/// `nvidia-gpu` compiles no platform verifiers, and this helper would be dead
+/// code there (the CI feature legs build with `-D warnings`).
+#[cfg(any(feature = "snp", feature = "tdx"))]
 pub(crate) fn check_expected(
     name: &'static str,
     actual: &[u8],

--- a/crates/attestation/src/utils.rs
+++ b/crates/attestation/src/utils.rs
@@ -105,7 +105,7 @@ pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 /// `nvidia-gpu` compiles no platform verifiers, and this helper would be dead
 /// code there (the CI feature legs build with `-D warnings`).
 #[cfg(any(feature = "snp", feature = "tdx"))]
-pub(crate) fn check_expected(
+pub(crate) fn check_expected_measurements_match(
     name: &'static str,
     actual: &[u8],
     expected: Option<&[u8]>,


### PR DESCRIPTION
Follow-up to #65 (and the RTMR[3] replay discussion).

## What

`expected_mrtd`, `expected_rtmr0..3` (TDX / az-tdx / gcp-tdx) and `expected_launch_digest` (SNP / az-snp / gcp-snp) were report-only: a mismatch came back as `Some(false)` in the `*_match` result fields and `verify` still returned `Ok`. Enforcement was left to the caller.

Now a supplied reference that doesn't match fails verification with a new `AttestationError::MeasurementMismatch("<register>")`. Semantics per field:

- not supplied → not checked (`None`, unchanged)
- supplied + match → `Some(true)` (unchanged)
- supplied + mismatch → verification **fails** (was `Some(false)`)

## Why

- Consistency: `expected_report_data` / `expected_init_data_hash` already hard-fail (`ReportDataMismatch` / `InitDataMismatch`). The measurement references were the odd ones out.
- Fail-closed: any caller that supplied a reference but forgot to read the `*_match` flags was silently fail-open. The CLI already treated `Some(false)` as exit-1; this moves that enforcement into the library where every consumer gets it.

This is the "if supplied, check it, and fail if the check fails" contract — including `expected_rtmr3`, which composes with #65: CCEL replay skips RTMR[3] (unreplayable by construction), while a relying party that knows the expected final value (e.g. the operator-key binding) pins it here and gets hard enforcement.

## Breaking

Callers that intentionally relied on `Ok` + `Some(false)` to observe a divergence without failing must drop the `expected_*` param and compare against the quote body themselves. The `*_match` fields keep their type for wire compatibility but can only carry `Some(true)` or be absent.