### PR TITLE
fix(az-snp): bound and retry the IMDS VCEK fetch

### DIFF
--- a/crates/attestation/src/platforms/az_snp/attest.rs
+++ b/crates/attestation/src/platforms/az_snp/attest.rs
@@ -108,28 +108,30 @@ async fn fetch_imds_certs(
     })
 }
 
-async fn get_imds_certs() -> Result<ImdsCertificates> {
-    // Same budget as the az_tdx IMDS call, which this one previously lacked
-    // entirely: without a timeout a stalled connect blocks evidence generation.
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .connect_timeout(Duration::from_secs(10))
-        .build()
-        .map_err(|e| AttestationError::CertFetchError(format!("build HTTP client: {}", e)))?;
-
-    let mut delay = IMDS_RETRY_DELAY;
+/// Calls `attempt_fn` until it succeeds, returns an error it marked
+/// non-retryable, or spends the attempt budget. `base_delay` doubles per retry.
+async fn retry_transient<T, F, Fut>(
+    attempts: u32,
+    base_delay: Duration,
+    mut attempt_fn: F,
+) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = std::result::Result<T, (AttestationError, bool)>>,
+{
+    let mut delay = base_delay;
     let mut attempt = 1;
     loop {
-        match fetch_imds_certs(&client).await {
-            Ok(certs) => return Ok(certs),
+        match attempt_fn().await {
+            Ok(value) => return Ok(value),
             Err((err, retryable)) => {
-                if !retryable || attempt == IMDS_ATTEMPTS {
+                if !retryable || attempt >= attempts {
                     return Err(err);
                 }
                 log::warn!(
                     "IMDS VCEK fetch attempt {}/{} failed, retrying in {:?}: {}",
                     attempt,
-                    IMDS_ATTEMPTS,
+                    attempts,
                     delay,
                     err
                 );
@@ -139,6 +141,21 @@ async fn get_imds_certs() -> Result<ImdsCertificates> {
             }
         }
     }
+}
+
+async fn get_imds_certs() -> Result<ImdsCertificates> {
+    // Same budget as the az_tdx IMDS call, which this one previously lacked
+    // entirely: without a timeout a stalled connect blocks evidence generation.
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .connect_timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| AttestationError::CertFetchError(format!("build HTTP client: {}", e)))?;
+
+    retry_transient(IMDS_ATTEMPTS, IMDS_RETRY_DELAY, || {
+        fetch_imds_certs(&client)
+    })
+    .await
 }
 
 /// Generate Azure SNP attestation evidence.
@@ -180,6 +197,7 @@ pub async fn generate_evidence(report_data: &[u8]) -> Result<AzSnpEvidence> {
 mod tests {
     use super::*;
     use reqwest::StatusCode;
+    use std::cell::Cell;
 
     #[test]
     fn throttling_and_server_faults_are_retryable() {
@@ -198,14 +216,65 @@ mod tests {
         assert!(!status_is_retryable(StatusCode::FORBIDDEN));
     }
 
-    #[test]
-    fn retry_budget_is_bounded() {
-        // Three tries with 200ms doubling keeps the added worst-case wait under
-        // a second on top of the request timeouts.
-        assert_eq!(IMDS_ATTEMPTS, 3);
-        let total: Duration = (0..IMDS_ATTEMPTS - 1)
-            .map(|i| IMDS_RETRY_DELAY * 2u32.pow(i))
-            .sum();
-        assert_eq!(total, Duration::from_millis(600));
+    fn transient() -> (AttestationError, bool) {
+        (
+            AttestationError::CertFetchError("IMDS unreachable".into()),
+            true,
+        )
+    }
+
+    fn fatal() -> (AttestationError, bool) {
+        (
+            AttestationError::CertFetchError("IMDS returned 400".into()),
+            false,
+        )
+    }
+
+    // Zero delay keeps these instant; the backoff schedule is a tuning knob,
+    // the loop's stop conditions are the behaviour worth pinning.
+    #[tokio::test]
+    async fn a_transient_failure_is_retried_until_it_succeeds() {
+        let calls = Cell::new(0);
+        let out = retry_transient(3, Duration::ZERO, || {
+            let n = calls.get() + 1;
+            calls.set(n);
+            async move {
+                if n < 3 {
+                    Err(transient())
+                } else {
+                    Ok(n)
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(out.unwrap(), 3);
+        assert_eq!(calls.get(), 3);
+    }
+
+    #[tokio::test]
+    async fn the_attempt_budget_is_the_cap() {
+        let calls = Cell::new(0);
+        let out: Result<u32> = retry_transient(3, Duration::ZERO, || {
+            calls.set(calls.get() + 1);
+            async { Err(transient()) }
+        })
+        .await;
+
+        assert!(out.is_err());
+        assert_eq!(calls.get(), 3, "must not exceed the budget");
+    }
+
+    #[tokio::test]
+    async fn a_non_retryable_error_returns_on_the_first_attempt() {
+        let calls = Cell::new(0);
+        let out: Result<u32> = retry_transient(3, Duration::ZERO, || {
+            calls.set(calls.get() + 1);
+            async { Err(fatal()) }
+        })
+        .await;
+
+        assert!(out.is_err());
+        assert_eq!(calls.get(), 1, "a stable answer must not be retried");
     }
 }

--- a/crates/attestation/src/platforms/az_snp/attest.rs
+++ b/crates/attestation/src/platforms/az_snp/attest.rs
@@ -121,25 +121,26 @@ where
 {
     let mut delay = base_delay;
     let mut attempt = 1;
+
     loop {
-        match attempt_fn().await {
+        // Three outcomes, and only the last one continues: success and a
+        // give-up both leave here, so the tail below is purely the backoff.
+        let err = match attempt_fn().await {
             Ok(value) => return Ok(value),
-            Err((err, retryable)) => {
-                if !retryable || attempt >= attempts {
-                    return Err(err);
-                }
-                log::warn!(
-                    "IMDS VCEK fetch attempt {}/{} failed, retrying in {:?}: {}",
-                    attempt,
-                    attempts,
-                    delay,
-                    err
-                );
-                tokio::time::sleep(delay).await;
-                delay *= 2;
-                attempt += 1;
-            }
-        }
+            Err((err, retryable)) if !retryable || attempt >= attempts => return Err(err),
+            Err((err, _)) => err,
+        };
+
+        log::warn!(
+            "IMDS VCEK fetch attempt {}/{} failed, retrying in {:?}: {}",
+            attempt,
+            attempts,
+            delay,
+            err
+        );
+        tokio::time::sleep(delay).await;
+        delay *= 2;
+        attempt += 1;
     }
 }
 

--- a/crates/attestation/src/platforms/az_snp/attest.rs
+++ b/crates/attestation/src/platforms/az_snp/attest.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD as BASE64URL, Engine};
 use serde::Deserialize;
 
@@ -10,6 +12,13 @@ use crate::utils::pad_report_data;
 use super::evidence::AzSnpEvidence;
 
 const IMDS_CERT_URL: &str = "http://169.254.169.254/metadata/THIM/amd/certification";
+
+/// IMDS is a per-VM service Azure documents as throttled and subject to
+/// transient unavailability, and this fetch sits on the evidence path: one
+/// blip otherwise fails the whole attestation. Bounded at three tries so a
+/// hard outage still surfaces quickly rather than hanging the caller.
+const IMDS_ATTEMPTS: u32 = 3;
+const IMDS_RETRY_DELAY: Duration = Duration::from_millis(200);
 
 #[derive(Deserialize)]
 struct ImdsCertificates {
@@ -56,20 +65,80 @@ fn quote_to_tpm_quote(q: vtpm::Quote) -> TpmQuote {
     }
 }
 
-async fn get_imds_certs() -> Result<ImdsCertificates> {
-    reqwest::Client::new()
+/// Whether another attempt could plausibly answer differently. Throttling and
+/// server-side faults are worth retrying; any other 4xx is a stable answer.
+fn status_is_retryable(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+}
+
+/// One IMDS attempt. The flag says whether a retry is worth doing.
+async fn fetch_imds_certs(
+    client: &reqwest::Client,
+) -> std::result::Result<ImdsCertificates, (AttestationError, bool)> {
+    let response = client
         .get(IMDS_CERT_URL)
         .header("Metadata", "true")
         .send()
         .await
-        .map_err(|e| AttestationError::CertFetchError(format!("IMDS request failed: {}", e)))?
-        .error_for_status()
-        .map_err(|e| AttestationError::CertFetchError(format!("IMDS returned error: {}", e)))?
-        .json()
-        .await
         .map_err(|e| {
-            AttestationError::CertFetchError(format!("failed to parse IMDS cert response: {}", e))
-        })
+            // The request is an idempotent GET, so any send-side failure is
+            // safe to repeat.
+            let transient = e.is_timeout() || e.is_connect() || e.is_request();
+            (
+                AttestationError::CertFetchError(format!("IMDS request failed: {}", e)),
+                transient,
+            )
+        })?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let retryable = status_is_retryable(status);
+        let body = response.text().await.unwrap_or_default();
+        return Err((
+            AttestationError::CertFetchError(format!("IMDS returned {}: {}", status, body)),
+            retryable,
+        ));
+    }
+
+    response.json().await.map_err(|e| {
+        (
+            AttestationError::CertFetchError(format!("failed to parse IMDS cert response: {}", e)),
+            false,
+        )
+    })
+}
+
+async fn get_imds_certs() -> Result<ImdsCertificates> {
+    // Same budget as the az_tdx IMDS call, which this one previously lacked
+    // entirely: without a timeout a stalled connect blocks evidence generation.
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .connect_timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| AttestationError::CertFetchError(format!("build HTTP client: {}", e)))?;
+
+    let mut delay = IMDS_RETRY_DELAY;
+    let mut attempt = 1;
+    loop {
+        match fetch_imds_certs(&client).await {
+            Ok(certs) => return Ok(certs),
+            Err((err, retryable)) => {
+                if !retryable || attempt == IMDS_ATTEMPTS {
+                    return Err(err);
+                }
+                log::warn!(
+                    "IMDS VCEK fetch attempt {}/{} failed, retrying in {:?}: {}",
+                    attempt,
+                    IMDS_ATTEMPTS,
+                    delay,
+                    err
+                );
+                tokio::time::sleep(delay).await;
+                delay *= 2;
+                attempt += 1;
+            }
+        }
+    }
 }
 
 /// Generate Azure SNP attestation evidence.
@@ -105,4 +174,38 @@ pub async fn generate_evidence(report_data: &[u8]) -> Result<AzSnpEvidence> {
         hcl_report: BASE64URL.encode(&hcl_report_bytes),
         vcek: BASE64URL.encode(&vcek_der),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::StatusCode;
+
+    #[test]
+    fn throttling_and_server_faults_are_retryable() {
+        assert!(status_is_retryable(StatusCode::TOO_MANY_REQUESTS));
+        assert!(status_is_retryable(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(status_is_retryable(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(status_is_retryable(StatusCode::GATEWAY_TIMEOUT));
+    }
+
+    #[test]
+    fn stable_client_errors_are_not_retryable() {
+        // A malformed or unauthorized THIM request answers the same way every
+        // time; retrying only multiplies the latency of a fixed failure.
+        assert!(!status_is_retryable(StatusCode::BAD_REQUEST));
+        assert!(!status_is_retryable(StatusCode::NOT_FOUND));
+        assert!(!status_is_retryable(StatusCode::FORBIDDEN));
+    }
+
+    #[test]
+    fn retry_budget_is_bounded() {
+        // Three tries with 200ms doubling keeps the added worst-case wait under
+        // a second on top of the request timeouts.
+        assert_eq!(IMDS_ATTEMPTS, 3);
+        let total: Duration = (0..IMDS_ATTEMPTS - 1)
+            .map(|i| IMDS_RETRY_DELAY * 2u32.pow(i))
+            .sum();
+        assert_eq!(total, Duration::from_millis(600));
+    }
 }


### PR DESCRIPTION
`get_imds_certs` fetched the VCEK from Azure THIM with a bare `reqwest::Client::new()`: one attempt, no timeout, no retry, on the SEV-SNP evidence path. Azure documents IMDS as throttled and subject to transient unavailability, so a blip on a remote metadata service fails the whole attestation, and a stalled connect blocks evidence generation for as long as the peer holds it open.

Two failures in our Azure SNP e2e lane on 2026-08-15 came in as `POST /attest -> 422` with `certificate fetch failed: IMDS request failed: error sending request`. The same ref passes now, so it was transient, which is exactly the case this had no answer for.

The sibling `az_tdx/attest.rs` already builds its client with the same 30s request / 10s connect budget for its own IMDS call, so this brings az_snp in line rather than inventing a policy. On top of that, three attempts with 200ms doubling, and only where a retry can change the answer: send-side transport failures (the request is an idempotent GET), 429, and 5xx. Any other 4xx returns immediately. Worst-case added wait is 600ms.

Non-success responses now report status and body like az_tdx does, instead of `error_for_status`'s status-only message, which is what made the original failure take a cluster teardown to diagnose.

Not covered: az_tdx has the same single-attempt shape and would benefit from the same retry, but it already has timeouts and was not the failure, so I left it alone rather than widen the blast radius on a path I cannot exercise here. The retry itself is unverified against real hardware for the same reason: the module is Linux and Azure-vTPM gated, so what I ran was the classification and budget logic plus a full build.

```
cargo fmt --all -- --check                     clean
cargo clippy ... az-snp-attest -D warnings     clean
cargo test -p attestation ... az_snp::attest   3 passed
```
(in a linux/amd64 container, since the module does not compile on darwin)