### PR TITLE
security(wasm): bring bare verify_snp to native-verifier parity; caller-supplied SNP CRL and min-TCB floor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "p384",
  "pem",
  "pem-rfc7468 1.0.0",
+ "rcgen",
  "reqwest",
  "rsa",
  "scroll",
@@ -236,6 +237,7 @@ dependencies = [
 name = "attestation-wasm"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "attestation",
  "base64 0.22.1",
  "serde_json",
@@ -1457,7 +1459,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "yasna",
+ "yasna 0.4.0",
  "zeroize",
 ]
 
@@ -2167,6 +2169,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna 0.5.2",
 ]
 
 [[package]]
@@ -3690,6 +3705,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
 dependencies = [
  "num-bigint",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/crates/attestation-wasm/Cargo.toml
+++ b/crates/attestation-wasm/Cargo.toml
@@ -14,6 +14,7 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 serde_json = "1"
 base64 = "0.22"
+async-trait = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/attestation-wasm/src/lib.rs
+++ b/crates/attestation-wasm/src/lib.rs
@@ -1,18 +1,71 @@
 use wasm_bindgen::prelude::*;
 
+use attestation::collateral::{CertProvider, DefaultCertProvider};
+use attestation::error::Result as AttestationResult;
 use attestation::platforms::az_snp::evidence::AzSnpEvidence;
-use attestation::platforms::az_snp::verify::verify_report;
+use attestation::platforms::az_snp::verify::{verify_report, VerifiedReport};
 use attestation::platforms::az_tdx::evidence::AzTdxEvidence;
 use attestation::platforms::az_tdx::verify::verify_evidence as verify_az_tdx_evidence;
-use attestation::platforms::snp::certs::get_bundled_certs;
+use attestation::platforms::snp::certs::get_ark;
 use attestation::platforms::snp::claims::extract_claims;
 use attestation::platforms::snp::verify::{
-    parse_report, verify_cert_chain, verify_report_signature,
+    check_vcek_not_revoked, enforce_min_tcb, parse_report, verify_report_signature,
+    verify_vek_endorsement, MAX_REPORT_VERSION,
 };
 use attestation::platforms::tdx::evidence::TdxEvidence;
 use attestation::platforms::tdx::verify::verify_evidence as verify_tdx_evidence;
-use attestation::types::{ProcessorGeneration, VerifyParams};
+use attestation::types::{ProcessorGeneration, SnpTcb, VerifyParams};
 use attestation::utils::{constant_time_eq, pad_report_data};
+
+/// Parse the optional minimum-TCB policy JSON (the [`SnpTcb`] shape:
+/// `{ "bootloader": u8, "tee": u8, "snp": u8, "microcode": u8, "fmc"?: u8 }`).
+fn parse_min_tcb(min_tcb_json: Option<String>) -> Result<Option<SnpTcb>, String> {
+    match min_tcb_json {
+        None => Ok(None),
+        Some(s) => serde_json::from_str(&s)
+            .map(Some)
+            .map_err(|e| format!("min_tcb deserialize: {e}")),
+    }
+}
+
+/// Cert provider for the generic offline entry point: VEK resolution and the
+/// ARK/ASK chain behave exactly like [`DefaultCertProvider`] on wasm (inline
+/// VEK required, bundled roots), but the SNP CRL is the caller-supplied DER
+/// blob instead of a network fetch. The core verifies the CRL's signature
+/// against the bundled ARK and its freshness before trusting it, so the bytes
+/// themselves need no transport trust.
+struct StaticSnpCollateral {
+    inner: DefaultCertProvider,
+    crl_der: Option<Vec<u8>>,
+}
+
+#[async_trait::async_trait]
+impl CertProvider for StaticSnpCollateral {
+    async fn get_snp_vcek(
+        &self,
+        processor_gen: ProcessorGeneration,
+        chip_id: &[u8; 64],
+        reported_tcb: &SnpTcb,
+    ) -> AttestationResult<Vec<u8>> {
+        self.inner
+            .get_snp_vcek(processor_gen, chip_id, reported_tcb)
+            .await
+    }
+
+    async fn get_snp_cert_chain(
+        &self,
+        processor_gen: ProcessorGeneration,
+    ) -> AttestationResult<(Vec<u8>, Vec<u8>)> {
+        self.inner.get_snp_cert_chain(processor_gen).await
+    }
+
+    async fn get_snp_crl(
+        &self,
+        _processor_gen: ProcessorGeneration,
+    ) -> AttestationResult<Option<Vec<u8>>> {
+        Ok(self.crl_der.clone())
+    }
+}
 
 /// Verify attestation evidence from a self-describing envelope — the generic,
 /// platform-dispatching entry point and the preferred API for JS embedders.
@@ -29,11 +82,25 @@ use attestation::utils::{constant_time_eq, pad_report_data};
 ///
 /// Runs in offline mode ([`attestation::Verifier::offline`]): quote signatures
 /// and cert chains verify against the bundled AMD/Intel roots (SNP evidence
-/// must carry its VEK inline, as c8s evidence does), the SNP processor
-/// generation is auto-detected from the report's CPUID fields (v3+ reports),
-/// and the network-backed collateral checks (PCK CRL, TCB status, QE identity)
-/// are skipped — `collateral_verified` stays `false`. Debug guests are always
-/// rejected (`allow_debug` is never exposed to the browser; fail closed).
+/// must carry its VEK inline, as c8s evidence does), and the SNP processor
+/// generation is auto-detected from the report's CPUID fields (v3+ reports).
+/// Debug guests are always rejected (`allow_debug` is never exposed to the
+/// browser; fail closed).
+///
+/// Collateral: the TDX network-backed checks (PCK CRL, TCB status, QE
+/// identity) need an async provider and are skipped. For SNP, the caller may
+/// staple the AMD KDS CRL as `snp_crl_der` — its signature is verified against
+/// the bundled ARK and its thisUpdate/nextUpdate window against the current
+/// time before it is trusted, then the VEK is checked against it and
+/// `collateral_verified` becomes `true`. Without it, revocation is skipped and
+/// `collateral_verified` stays `false` — the caller's policy layer decides
+/// whether that qualifies as verified.
+///
+/// `min_tcb_json`, when supplied, is the minimum SNP TCB policy as
+/// [`SnpTcb`] JSON (`{ "bootloader": u8, "tee": u8, "snp": u8,
+/// "microcode": u8, "fmc"?: u8 }`); a report whose reported TCB is below any
+/// component fails closed. SNP platforms only — it is ignored by the TDX
+/// verifiers, so TDX callers must not rely on it.
 ///
 /// The freshness semantics of `expected_report_data` are per-platform, handled
 /// inside each core verifier: for bare-metal platforms it is checked against
@@ -45,6 +112,8 @@ use attestation::utils::{constant_time_eq, pad_report_data};
 /// - `expected_report_data`: optional freshness anchor bytes
 /// - `expected_init_data_hash`: optional init-data binding (SNP HOST_DATA /
 ///   TDX MRCONFIGID / vTPM PCR[8])
+/// - `min_tcb_json`: optional minimum SNP TCB policy ([`SnpTcb`] JSON)
+/// - `snp_crl_der`: optional DER AMD KDS CRL for the report's generation
 ///
 /// Returns the [`attestation::types::VerificationResult`] as JSON, or throws
 /// on any check failure.
@@ -53,14 +122,22 @@ pub async fn verify(
     envelope_json: String,
     expected_report_data: Option<Vec<u8>>,
     expected_init_data_hash: Option<Vec<u8>>,
+    min_tcb_json: Option<String>,
+    snp_crl_der: Option<Vec<u8>>,
 ) -> Result<String, JsError> {
+    let min_tcb = parse_min_tcb(min_tcb_json).map_err(|e| JsError::new(&e))?;
     let params = VerifyParams {
         expected_report_data,
         expected_init_data_hash,
+        min_tcb,
         ..VerifyParams::default()
     };
 
     let result = attestation::Verifier::offline()
+        .with_cert_provider(StaticSnpCollateral {
+            inner: DefaultCertProvider::new(),
+            crl_der: snp_crl_der,
+        })
         .verify(envelope_json.as_bytes(), &params)
         .await
         .map_err(|e| JsError::new(&format!("verify: {e}")))?;
@@ -70,9 +147,35 @@ pub async fn verify(
 
 /// Verify live SNP evidence in WASM.
 ///
+/// Enforces the same endorsement-key and platform-security policy as the
+/// native SNP verifier (`platforms/snp/verify.rs`), minus only VEK fetching
+/// (the VEK must be inline). The one intentional difference from the generic
+/// [`verify`] entry point is the explicit `generation` argument: v2 reports
+/// (Azure HCL evidence unwrapped to a bare report) carry no CPUID fields to
+/// auto-detect from, so the caller declares the generation and the VEK chain
+/// check authenticates it — a wrong declaration fails its own chain.
+///
+/// Checks, in native order: ARK → ASK/ASVK → VEK chain against the bundled
+/// roots (VLEK auto-detected), VEK validity period, optional CRL revocation,
+/// report signature, VMPL == 0, debug-policy rejection (no opt-in here; fail
+/// closed), VEK chip-id/TCB OID cross-validation against the report, and the
+/// optional minimum-TCB floor.
+///
+/// Collateral: when `crl_der` carries the AMD KDS CRL for this generation,
+/// its signature is verified against the bundled ARK and its
+/// thisUpdate/nextUpdate window against the current time, then the VEK is
+/// checked against it and the result's `collateral_verified` is `true`.
+/// Without it, revocation is skipped and `collateral_verified` is `false` —
+/// surfaced, never silently upgraded.
+///
 /// - `evidence_json`: evidence JSON with inline cert_chain.vcek
 /// - `generation`: processor generation ("milan", "genoa", "turin")
-/// - `expected_report_data`: optional raw bytes to check against report_data in the report
+/// - `expected_report_data`: optional raw bytes to check against report_data
+///   in the report (comparison reported as `report_data_match`, not fatal —
+///   the policy layer decides)
+/// - `min_tcb_json`: optional minimum SNP TCB policy ([`SnpTcb`] JSON); a
+///   reported TCB below any component fails closed
+/// - `crl_der`: optional DER AMD KDS CRL for this generation
 ///
 /// Returns verification result as JSON.
 #[wasm_bindgen]
@@ -80,42 +183,86 @@ pub fn verify_snp(
     evidence_json: &str,
     generation: &str,
     expected_report_data: Option<Vec<u8>>,
+    min_tcb_json: Option<String>,
+    crl_der: Option<Vec<u8>>,
 ) -> Result<String, JsError> {
+    verify_snp_impl(
+        evidence_json,
+        generation,
+        expected_report_data,
+        min_tcb_json,
+        crl_der,
+    )
+    .map_err(|e| JsError::new(&e))
+}
+
+// The whole entry point behind the wasm-bindgen boundary, so every enforcement
+// gate is exercisable by native tests (JsError carries no readable message off
+// the wasm target). Behavior-identical to the wrapper.
+fn verify_snp_impl(
+    evidence_json: &str,
+    generation: &str,
+    expected_report_data: Option<Vec<u8>>,
+    min_tcb_json: Option<String>,
+    crl_der: Option<Vec<u8>>,
+) -> Result<String, String> {
     let gen = match generation {
         "milan" | "Milan" => ProcessorGeneration::Milan,
         "genoa" | "Genoa" => ProcessorGeneration::Genoa,
         "turin" | "Turin" => ProcessorGeneration::Turin,
-        _ => return Err(JsError::new(&format!("unknown generation: {generation}"))),
+        _ => return Err(format!("unknown generation: {generation}")),
     };
+    let min_tcb = parse_min_tcb(min_tcb_json)?;
 
     let evidence: attestation::platforms::snp::evidence::SnpEvidence =
-        serde_json::from_str(evidence_json)
-            .map_err(|e| JsError::new(&format!("evidence deserialize: {e}")))?;
+        serde_json::from_str(evidence_json).map_err(|e| format!("evidence deserialize: {e}"))?;
 
     use base64::Engine;
     let report_bytes = base64::engine::general_purpose::STANDARD
         .decode(&evidence.attestation_report)
-        .map_err(|e| JsError::new(&format!("base64 decode report: {e}")))?;
+        .map_err(|e| format!("base64 decode report: {e}"))?;
 
-    let report =
-        parse_report(&report_bytes).map_err(|e| JsError::new(&format!("parse report: {e}")))?;
+    let report = parse_report(&report_bytes).map_err(|e| format!("parse report: {e}"))?;
+
+    // Same version window as the native az-snp path: v2 (HCL-unwrapped, no
+    // CPUID fields) up to the shared maximum.
+    const MIN_REPORT_VERSION: u32 = 2;
+    if report.version < MIN_REPORT_VERSION || report.version > MAX_REPORT_VERSION {
+        return Err(format!(
+            "report version {} not supported (min: {MIN_REPORT_VERSION}, max: {MAX_REPORT_VERSION})",
+            report.version
+        ));
+    }
 
     // Get VCEK from evidence
-    let vcek_der = match &evidence.cert_chain {
+    let vek_der = match &evidence.cert_chain {
         Some(chain) => base64::engine::general_purpose::STANDARD
             .decode(&chain.vcek)
-            .map_err(|e| JsError::new(&format!("base64 decode vcek: {e}")))?,
-        None => return Err(JsError::new("evidence missing cert_chain.vcek")),
+            .map_err(|e| format!("base64 decode vcek: {e}"))?,
+        None => return Err("evidence missing cert_chain.vcek".to_string()),
     };
 
-    // Verify cert chain (bundled ARK/ASK -> VCEK)
-    let (ark, ask) = get_bundled_certs(gen);
-    verify_cert_chain(ark, ask, &vcek_der)
-        .map_err(|e| JsError::new(&format!("cert chain verify: {e}")))?;
+    // Endorsement-key policy: bundled ARK → ASK/ASVK → VEK chain, VEK validity
+    // period, and VEK chip-id/TCB OID cross-validation against the report —
+    // the checks whose absence let an expired or wrong-platform VEK vouch for
+    // a report here while the native verifier rejected it.
+    verify_vek_endorsement(&report, &vek_der, gen).map_err(|e| format!("VEK endorsement: {e}"))?;
+
+    // CRL revocation check — caller-supplied collateral, ARK-signature- and
+    // freshness-verified before it is trusted (AMD CRLs are signed by the
+    // ARK, not the ASK/ASVK intermediate).
+    let collateral_verified = match crl_der {
+        Some(crl) => {
+            check_vcek_not_revoked(&vek_der, &crl, get_ark(gen))
+                .map_err(|e| format!("CRL check: {e}"))?;
+            true
+        }
+        None => false,
+    };
 
     // Verify report signature
-    verify_report_signature(&report_bytes, &vcek_der)
-        .map_err(|e| JsError::new(&format!("report signature: {e}")))?;
+    verify_report_signature(&report_bytes, &vek_der)
+        .map_err(|e| format!("report signature: {e}"))?;
 
     // Guest-policy enforcement — mirrors the native `verify_report` path
     // (`platforms/snp/verify.rs`: VMPL==0 and debug-policy rejection). Without
@@ -128,15 +275,21 @@ pub fn verify_snp(
     // `allow_debug` opt-in: it fails closed. (SEV-SNP guest policy lives in the
     // report, not the launch measurement, so a measurement pin cannot catch this.)
     if report.vmpl != 0 {
-        return Err(JsError::new(&format!(
+        return Err(format!(
             "VMPL check failed: report VMPL is {} (expected 0)",
             report.vmpl
-        )));
+        ));
     }
     if report.policy.debug_allowed() {
-        return Err(JsError::new(
-            "SNP guest policy permits debug (host can read guest memory); rejecting (fail closed)",
-        ));
+        return Err(
+            "SNP guest policy permits debug (host can read guest memory); rejecting (fail closed)"
+                .to_string(),
+        );
+    }
+
+    // Minimum-TCB floor
+    if let Some(ref min) = min_tcb {
+        enforce_min_tcb(&report.reported_tcb, min).map_err(|e| format!("minimum TCB: {e}"))?;
     }
 
     // Check report_data binding
@@ -153,10 +306,11 @@ pub fn verify_snp(
         "platform": "snp",
         "report_version": report.version,
         "report_data_match": report_data_match,
+        "collateral_verified": collateral_verified,
         "claims": claims,
     });
 
-    serde_json::to_string_pretty(&result).map_err(|e| JsError::new(&format!("json serialize: {e}")))
+    serde_json::to_string_pretty(&result).map_err(|e| format!("json serialize: {e}"))
 }
 
 /// Verify Azure SEV-SNP (az-snp) vTPM attestation evidence in WASM.
@@ -167,20 +321,25 @@ pub fn verify_snp(
 /// the TPM quote's `extraData` (qualifyingData), not in the SNP `report_data`
 /// — the SNP `report_data` instead binds the vTPM attestation key (AK).
 ///
-/// Verification (mirrors the native async path, minus the CRL revocation check
-/// which needs an async cert provider — so `collateral_verified` is always
-/// `false` here):
+/// Verification (mirrors the native async path):
 /// 1. Verify the TPM quote signature with the AK extracted from HCL var_data.
 /// 2. Check the quote's `extraData` equals `expected_report_data` (freshness),
 ///    failing closed when an anchor is supplied and does not match.
 /// 3. Verify the PCR digest, and optionally bind PCR[8] to `expected_init_data_hash`.
 /// 4. Bind the AK to the TEE: `snp.report_data[..32] == SHA-256(var_data)`.
 /// 5. Validate the VCEK chain (auto-detecting the generation from CPUID) and the
-///    SNP report signature, then enforce VMPL/debug/TCB policy.
+///    SNP report signature, then enforce VMPL/debug/TCB policy and the optional
+///    minimum-TCB floor.
+/// 6. When `crl_der` carries the AMD KDS CRL for the matched generation, verify
+///    its ARK signature and freshness, then check the VCEK against it —
+///    `collateral_verified` becomes `true`. Without it, revocation is skipped
+///    and `collateral_verified` stays `false`.
 ///
 /// - `evidence_json`: az-snp evidence JSON (`{ version, tpm_quote, hcl_report, vcek }`)
 /// - `expected_report_data`: optional raw bytes the TPM quote `extraData` must equal
 /// - `expected_init_data_hash`: optional 32-byte hash to bind against PCR[8]
+/// - `min_tcb_json`: optional minimum SNP TCB policy ([`SnpTcb`] JSON)
+/// - `crl_der`: optional DER AMD KDS CRL for the report's generation
 ///
 /// Returns the verification result as JSON, or throws on any check failure.
 #[wasm_bindgen]
@@ -188,9 +347,30 @@ pub fn verify_az_snp(
     evidence_json: &str,
     expected_report_data: Option<Vec<u8>>,
     expected_init_data_hash: Option<Vec<u8>>,
+    min_tcb_json: Option<String>,
+    crl_der: Option<Vec<u8>>,
 ) -> Result<String, JsError> {
-    let evidence: AzSnpEvidence = serde_json::from_str(evidence_json)
-        .map_err(|e| JsError::new(&format!("evidence deserialize: {e}")))?;
+    verify_az_snp_impl(
+        evidence_json,
+        expected_report_data,
+        expected_init_data_hash,
+        min_tcb_json,
+        crl_der,
+    )
+    .map_err(|e| JsError::new(&e))
+}
+
+// Off-wasm-testable body, same rationale as verify_snp_impl / verify_tdx_impl.
+fn verify_az_snp_impl(
+    evidence_json: &str,
+    expected_report_data: Option<Vec<u8>>,
+    expected_init_data_hash: Option<Vec<u8>>,
+    min_tcb_json: Option<String>,
+    crl_der: Option<Vec<u8>>,
+) -> Result<String, String> {
+    let evidence: AzSnpEvidence =
+        serde_json::from_str(evidence_json).map_err(|e| format!("evidence deserialize: {e}"))?;
+    let min_tcb = parse_min_tcb(min_tcb_json)?;
 
     // Run the full az-snp verification core, freshness included. When an anchor is
     // supplied, the core binds the TPM quote's extraData (qualifyingData) to it and
@@ -201,19 +381,34 @@ pub fn verify_az_snp(
     let params = VerifyParams {
         expected_report_data,
         expected_init_data_hash,
+        min_tcb,
         ..VerifyParams::default()
     };
 
-    let verified = verify_report(&evidence, &params)
-        .map_err(|e| JsError::new(&format!("az-snp verify: {e}")))?;
+    let VerifiedReport {
+        mut result,
+        matched_gen,
+        vcek_der,
+        report_version,
+    } = verify_report(&evidence, &params).map_err(|e| format!("az-snp verify: {e}"))?;
+
+    // CRL revocation check — caller-supplied collateral, exactly the check the
+    // native async wrapper (`az_snp::verify::verify_evidence`) runs with a
+    // provider-fetched CRL. AMD CRLs are signed by the ARK, not the ASK/ASVK
+    // intermediate, and the CRL's signature and freshness are verified before
+    // it is trusted.
+    if let Some(crl) = crl_der {
+        check_vcek_not_revoked(&vcek_der, &crl, get_ark(matched_gen))
+            .map_err(|e| format!("CRL check: {e}"))?;
+        result.collateral_verified = true;
+    }
 
     // Serialize the VerificationResult, then graft on report_version, matching the
     // shape verify_snp returns so the JS policy layer reads it uniformly.
-    let mut result = serde_json::to_value(&verified.result)
-        .map_err(|e| JsError::new(&format!("json serialize: {e}")))?;
-    result["report_version"] = serde_json::json!(verified.report_version);
+    let mut result = serde_json::to_value(&result).map_err(|e| format!("json serialize: {e}"))?;
+    result["report_version"] = serde_json::json!(report_version);
 
-    serde_json::to_string_pretty(&result).map_err(|e| JsError::new(&format!("json serialize: {e}")))
+    serde_json::to_string_pretty(&result).map_err(|e| format!("json serialize: {e}"))
 }
 
 /// Verify bare-metal Intel TDX (tdx) DCAP attestation evidence in WASM.
@@ -460,6 +655,141 @@ mod tests {
                 "length {len}: error must name the size contract, got: {err}"
             );
         }
+    }
+
+    // --- bare-SNP entry point: endorsement parity, min-TCB floor, CRL ---
+
+    const SNP_REPORT_V5: &[u8] =
+        include_bytes!("../../attestation/test_data/snp/live-report-v5-genoa.bin");
+    const SNP_VCEK_GENOA: &[u8] =
+        include_bytes!("../../attestation/test_data/snp/live-vcek-genoa.der");
+    const AZ_SNP_MILAN_V3: &str =
+        include_str!("../../attestation/test_data/az_snp/milan-v3-attestation.json");
+
+    fn snp_evidence_json() -> String {
+        serde_json::json!({
+            "attestation_report": BASE64.encode(SNP_REPORT_V5),
+            "cert_chain": { "vcek": BASE64.encode(SNP_VCEK_GENOA) },
+        })
+        .to_string()
+    }
+
+    fn reported_tcb_json(microcode_bump: u8) -> String {
+        let report = parse_report(SNP_REPORT_V5).unwrap();
+        let tcb = report.reported_tcb;
+        serde_json::json!({
+            "bootloader": tcb.bootloader,
+            "tee": tcb.tee,
+            "snp": tcb.snp,
+            "microcode": tcb.microcode + microcode_bump,
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn snp_valid_evidence_passes_without_collateral() {
+        let out = verify_snp_impl(&snp_evidence_json(), "genoa", None, None, None)
+            .expect("live genoa fixture must verify");
+        let json: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(json["signature_valid"], serde_json::json!(true));
+        assert_eq!(json["report_version"], serde_json::json!(5));
+        assert_eq!(
+            json["collateral_verified"],
+            serde_json::json!(false),
+            "no CRL supplied ⇒ revocation was not checked, and the result must say so"
+        );
+    }
+
+    #[test]
+    fn snp_wrong_generation_fails_chain() {
+        let err = verify_snp_impl(&snp_evidence_json(), "milan", None, None, None)
+            .expect_err("declared generation must be authenticated by the VEK chain");
+        assert!(err.contains("VEK endorsement"), "got: {err}");
+    }
+
+    #[test]
+    fn snp_min_tcb_at_floor_passes() {
+        verify_snp_impl(
+            &snp_evidence_json(),
+            "genoa",
+            None,
+            Some(reported_tcb_json(0)),
+            None,
+        )
+        .expect("reported TCB at the floor must pass");
+    }
+
+    #[test]
+    fn snp_min_tcb_below_floor_fails_closed() {
+        let err = verify_snp_impl(
+            &snp_evidence_json(),
+            "genoa",
+            None,
+            Some(reported_tcb_json(1)),
+            None,
+        )
+        .expect_err("below-floor TCB must fail closed");
+        assert!(err.contains("below minimum"), "got: {err}");
+    }
+
+    #[test]
+    fn snp_malformed_min_tcb_rejected_before_verification() {
+        for bad in ["not json", "{}", r#"{"bootloader": 3}"#] {
+            let err = verify_snp_impl(
+                &snp_evidence_json(),
+                "genoa",
+                None,
+                Some(bad.to_string()),
+                None,
+            )
+            .expect_err("malformed min_tcb must be rejected, not dropped");
+            assert!(err.contains("min_tcb deserialize"), "{bad}: got {err}");
+        }
+    }
+
+    #[test]
+    fn snp_garbage_crl_rejected() {
+        let err = verify_snp_impl(
+            &snp_evidence_json(),
+            "genoa",
+            None,
+            None,
+            Some(vec![0xAB; 64]),
+        )
+        .expect_err("unparseable CRL must fail closed, never read as checked");
+        assert!(err.contains("CRL check"), "got: {err}");
+    }
+
+    // --- az-snp entry point: min-TCB floor and CRL pass-through ---
+
+    #[test]
+    fn az_snp_min_tcb_below_floor_fails_closed() {
+        let evidence: serde_json::Value = serde_json::from_str(AZ_SNP_MILAN_V3).unwrap();
+        let evidence = evidence["evidence"].to_string();
+        // A floor above any real Milan microcode SPL.
+        let floor = r#"{"bootloader":0,"tee":0,"snp":0,"microcode":255}"#;
+        let err = verify_az_snp_impl(&evidence, None, None, Some(floor.to_string()), None)
+            .expect_err("below-floor TCB must fail closed on az-snp too");
+        assert!(err.contains("below minimum"), "got: {err}");
+    }
+
+    #[test]
+    fn az_snp_garbage_crl_rejected() {
+        let evidence: serde_json::Value = serde_json::from_str(AZ_SNP_MILAN_V3).unwrap();
+        let evidence = evidence["evidence"].to_string();
+        let err = verify_az_snp_impl(&evidence, None, None, None, Some(vec![0xAB; 64]))
+            .expect_err("unparseable CRL must fail closed");
+        assert!(err.contains("CRL check"), "got: {err}");
+    }
+
+    #[test]
+    fn az_snp_no_collateral_surfaces_false() {
+        let evidence: serde_json::Value = serde_json::from_str(AZ_SNP_MILAN_V3).unwrap();
+        let evidence = evidence["evidence"].to_string();
+        let out = verify_az_snp_impl(&evidence, None, None, None, None)
+            .expect("milan v3 fixture must verify");
+        let json: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(json["collateral_verified"], serde_json::json!(false));
     }
 
     #[tokio::test]

--- a/crates/attestation/Cargo.toml
+++ b/crates/attestation/Cargo.toml
@@ -117,6 +117,8 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 criterion = { version = "0.5", features = ["async_tokio"] }
 async-trait = "0.1"
 tempfile = "3"
+rcgen = { version = "0.13", default-features = false, features = ["pem", "crypto", "ring"] }
+time = { version = "0.3", features = ["std", "macros"] }
 
 [[bench]]
 name = "snp"

--- a/crates/attestation/src/platforms/az_snp/verify.rs
+++ b/crates/attestation/src/platforms/az_snp/verify.rs
@@ -184,6 +184,9 @@ pub fn verify_report(evidence: &AzSnpEvidence, params: &VerifyParams) -> Result<
         })
     })?;
 
+    // VCEK/VLEK validity period — same check as the bare-metal SNP path (6b).
+    crate::platforms::snp::verify::verify_vek_validity_period(&vcek_der)?;
+
     // SNP report signature against VCEK
     crate::platforms::snp::verify::verify_report_signature(&hcl.tee_report, &vcek_der)?;
 

--- a/crates/attestation/src/platforms/snp/verify.rs
+++ b/crates/attestation/src/platforms/snp/verify.rs
@@ -285,7 +285,7 @@ pub fn verify_report_signature(report_bytes: &[u8], vcek_der: &[u8]) -> Result<(
 }
 
 /// Verify a VEK (VCEK/VLEK) certificate's validity period (notBefore/notAfter).
-fn verify_vek_validity_period(vek_der: &[u8]) -> Result<()> {
+pub fn verify_vek_validity_period(vek_der: &[u8]) -> Result<()> {
     let (_, cert) = X509Certificate::from_der(vek_der).map_err(|e| {
         AttestationError::CertChainError(format!("VEK x509 parse for validity: {e}"))
     })?;
@@ -303,6 +303,30 @@ fn verify_vek_validity_period(vek_der: &[u8]) -> Result<()> {
             validity.not_after
         )));
     }
+    Ok(())
+}
+
+/// Verify the full endorsement-key policy for an inline VEK against the
+/// bundled AMD roots: the ARK → ASK/ASVK → VEK chain (VLEK auto-detected from
+/// the certificate CN), the VEK validity period, and the VEK's chip-id/TCB OID
+/// cross-validation against the report. This is steps 6–6b and 8c of
+/// [`verify_evidence`] as one unit, for callers that resolve the VEK
+/// themselves (notably the WASM `verify_snp` entry point). Revocation is out
+/// of scope — pair with [`check_vcek_not_revoked`] when CRL data is available.
+pub fn verify_vek_endorsement(
+    report: &AttestationReport,
+    vek_der: &[u8],
+    processor_gen: ProcessorGeneration,
+) -> Result<()> {
+    let ark_der = super::certs::get_ark(processor_gen);
+    let intermediate_der = if is_vlek_cert(vek_der)? {
+        super::certs::get_asvk(processor_gen)
+    } else {
+        super::certs::get_ask(processor_gen)
+    };
+    verify_cert_chain(ark_der, intermediate_der, vek_der)?;
+    verify_vek_validity_period(vek_der)?;
+    verify_vcek_tcb(report, vek_der, processor_gen)?;
     Ok(())
 }
 
@@ -508,6 +532,32 @@ pub fn check_vcek_not_revoked(vcek_der: &[u8], crl_der: &[u8], issuer_der: &[u8]
     // We use our own implementation because x509-parser's verify_signature
     // doesn't support RSA-PSS (used by Milan ASK for CRL signing).
     verify_crl_signature(&crl, crl_der, &issuer_cert)?;
+
+    // 3b. Freshness: a genuine but stale CRL must not vouch for a VEK that a
+    // newer list may have revoked. AMD CRLs always carry nextUpdate; one
+    // without it has no defined shelf life, so it is rejected rather than
+    // trusted forever.
+    let now = x509_parser::time::ASN1Time::now();
+    if crl.last_update() > now {
+        return Err(AttestationError::CertChainError(format!(
+            "AMD CRL thisUpdate {} is in the future",
+            crl.last_update()
+        )));
+    }
+    match crl.next_update() {
+        None => {
+            return Err(AttestationError::CertChainError(
+                "AMD CRL has no nextUpdate; refusing a revocation list with no defined freshness"
+                    .into(),
+            ));
+        }
+        Some(next_update) if next_update < now => {
+            return Err(AttestationError::CertChainError(format!(
+                "AMD CRL is stale: nextUpdate {next_update} has passed; fetch a current CRL"
+            )));
+        }
+        Some(_) => {}
+    }
 
     // 4. Check serial number against revocation list
     let (_, cert) = X509Certificate::from_der(vcek_der)
@@ -1079,6 +1129,231 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(r.launch_digest_match, Some(true));
+    }
+
+    // ---------------------------------------------------------------
+    // Endorsement policy negative tests: VEK validity, TCB floor, and
+    // CRL revocation/freshness, with rcgen-minted certificates and CRLs
+    // (an ARK-signed CRL naming a fixture serial cannot be produced, so
+    // the CRL contract is proven against a test issuer instead).
+    // ---------------------------------------------------------------
+
+    use time::macros::datetime;
+    use time::{Duration as TimeDuration, OffsetDateTime};
+
+    fn mint_issuer(cn: &str) -> (rcgen::Certificate, rcgen::KeyPair) {
+        let key = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P384_SHA384).unwrap();
+        let mut params = rcgen::CertificateParams::new(Vec::<String>::new()).unwrap();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, cn);
+        (params.self_signed(&key).unwrap(), key)
+    }
+
+    fn mint_leaf(serial: &[u8], not_before: OffsetDateTime, not_after: OffsetDateTime) -> Vec<u8> {
+        let key = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P384_SHA384).unwrap();
+        let mut params = rcgen::CertificateParams::new(Vec::<String>::new()).unwrap();
+        params.serial_number = Some(rcgen::SerialNumber::from_slice(serial));
+        params.not_before = not_before;
+        params.not_after = not_after;
+        params.self_signed(&key).unwrap().der().to_vec()
+    }
+
+    fn mint_crl(
+        issuer: &(rcgen::Certificate, rcgen::KeyPair),
+        revoked_serial: Option<&[u8]>,
+        this_update: OffsetDateTime,
+        next_update: OffsetDateTime,
+    ) -> Vec<u8> {
+        let params = rcgen::CertificateRevocationListParams {
+            this_update,
+            next_update,
+            crl_number: rcgen::SerialNumber::from(1234u64),
+            issuing_distribution_point: None,
+            revoked_certs: revoked_serial
+                .map(|serial| {
+                    vec![rcgen::RevokedCertParams {
+                        serial_number: rcgen::SerialNumber::from_slice(serial),
+                        revocation_time: this_update,
+                        reason_code: None,
+                        invalidity_date: None,
+                    }]
+                })
+                .unwrap_or_default(),
+            key_identifier_method: rcgen::KeyIdMethod::Sha256,
+        };
+        params
+            .signed_by(&issuer.0, &issuer.1)
+            .unwrap()
+            .der()
+            .to_vec()
+    }
+
+    const LEAF_SERIAL: &[u8] = &[0x01, 0x02, 0x03, 0x04];
+
+    fn valid_window() -> (OffsetDateTime, OffsetDateTime) {
+        let now = OffsetDateTime::now_utc();
+        (now - TimeDuration::days(1), now + TimeDuration::days(1))
+    }
+
+    #[test]
+    fn test_vek_expired_rejected() {
+        let leaf = mint_leaf(
+            LEAF_SERIAL,
+            datetime!(2020-01-01 0:00 UTC),
+            datetime!(2021-01-01 0:00 UTC),
+        );
+        let err = verify_vek_validity_period(&leaf).expect_err("expired VEK must be rejected");
+        assert!(err.to_string().contains("expired"), "got: {err}");
+    }
+
+    #[test]
+    fn test_vek_not_yet_valid_rejected() {
+        let leaf = mint_leaf(
+            LEAF_SERIAL,
+            datetime!(2100-01-01 0:00 UTC),
+            datetime!(2101-01-01 0:00 UTC),
+        );
+        let err = verify_vek_validity_period(&leaf).expect_err("future VEK must be rejected");
+        assert!(err.to_string().contains("not yet valid"), "got: {err}");
+    }
+
+    #[test]
+    fn test_vek_current_accepted() {
+        let (not_before, not_after) = valid_window();
+        let leaf = mint_leaf(LEAF_SERIAL, not_before, not_after);
+        verify_vek_validity_period(&leaf).expect("current VEK must pass");
+    }
+
+    #[test]
+    fn test_crl_revoked_vek_rejected() {
+        let issuer = mint_issuer("TEST-ARK");
+        let (not_before, not_after) = valid_window();
+        let leaf = mint_leaf(LEAF_SERIAL, not_before, not_after);
+        let crl = mint_crl(&issuer, Some(LEAF_SERIAL), not_before, not_after);
+        let err = check_vcek_not_revoked(&leaf, &crl, issuer.0.der())
+            .expect_err("revoked serial must be rejected");
+        assert!(err.to_string().contains("revoked"), "got: {err}");
+    }
+
+    #[test]
+    fn test_crl_fresh_nonrevoked_accepted() {
+        let issuer = mint_issuer("TEST-ARK");
+        let (not_before, not_after) = valid_window();
+        let leaf = mint_leaf(LEAF_SERIAL, not_before, not_after);
+        let crl = mint_crl(&issuer, Some(&[0xEE; 4]), not_before, not_after);
+        check_vcek_not_revoked(&leaf, &crl, issuer.0.der())
+            .expect("fresh CRL not naming the serial must pass");
+    }
+
+    #[test]
+    fn test_crl_stale_rejected() {
+        let issuer = mint_issuer("TEST-ARK");
+        let (not_before, not_after) = valid_window();
+        let leaf = mint_leaf(LEAF_SERIAL, not_before, not_after);
+        let now = OffsetDateTime::now_utc();
+        // nextUpdate already passed: a genuine but stale list must not vouch.
+        let crl = mint_crl(
+            &issuer,
+            None,
+            now - TimeDuration::days(30),
+            now - TimeDuration::days(1),
+        );
+        let err = check_vcek_not_revoked(&leaf, &crl, issuer.0.der())
+            .expect_err("stale CRL must be rejected");
+        assert!(err.to_string().contains("stale"), "got: {err}");
+    }
+
+    #[test]
+    fn test_crl_from_future_rejected() {
+        let issuer = mint_issuer("TEST-ARK");
+        let (not_before, not_after) = valid_window();
+        let leaf = mint_leaf(LEAF_SERIAL, not_before, not_after);
+        let now = OffsetDateTime::now_utc();
+        let crl = mint_crl(
+            &issuer,
+            None,
+            now + TimeDuration::days(1),
+            now + TimeDuration::days(30),
+        );
+        let err = check_vcek_not_revoked(&leaf, &crl, issuer.0.der())
+            .expect_err("future-dated CRL must be rejected");
+        assert!(err.to_string().contains("future"), "got: {err}");
+    }
+
+    #[test]
+    fn test_crl_wrong_issuer_rejected() {
+        let signer = mint_issuer("TEST-ARK");
+        let impostor = mint_issuer("OTHER-ARK");
+        let (not_before, not_after) = valid_window();
+        let leaf = mint_leaf(LEAF_SERIAL, not_before, not_after);
+        // An empty CRL signed by a key the verifier does not trust must not
+        // clear the check — this is exactly the forged-empty-CRL bypass.
+        let crl = mint_crl(&signer, None, not_before, not_after);
+        let err = check_vcek_not_revoked(&leaf, &crl, impostor.0.der())
+            .expect_err("CRL signed by the wrong issuer must be rejected");
+        assert!(
+            err.to_string().contains("signature verification failed"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_vcek_tcb_report_mismatch_rejected() {
+        let mut report = parse_report(LIVE_REPORT_V5).expect("parse report");
+        report.reported_tcb.microcode = report.reported_tcb.microcode.wrapping_add(1);
+        let err = verify_vcek_tcb(&report, LIVE_VCEK_GENOA, ProcessorGeneration::Genoa)
+            .expect_err("VEK/report TCB disagreement must be rejected");
+        assert!(
+            matches!(err, AttestationError::TcbMismatch(_)),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_enforce_min_tcb_at_floor_passes() {
+        let report = parse_report(LIVE_REPORT_V5).unwrap();
+        let tcb = &report.reported_tcb;
+        let floor = SnpTcb {
+            bootloader: tcb.bootloader,
+            tee: tcb.tee,
+            snp: tcb.snp,
+            microcode: tcb.microcode,
+            fmc: None,
+        };
+        enforce_min_tcb(tcb, &floor).expect("reported TCB at the floor must pass");
+    }
+
+    #[test]
+    fn test_enforce_min_tcb_below_floor_rejected() {
+        let report = parse_report(LIVE_REPORT_V5).unwrap();
+        let tcb = &report.reported_tcb;
+        let floor = SnpTcb {
+            bootloader: tcb.bootloader,
+            tee: tcb.tee,
+            snp: tcb.snp,
+            microcode: tcb.microcode + 1,
+            fmc: None,
+        };
+        let err = enforce_min_tcb(tcb, &floor).expect_err("below-floor TCB must be rejected");
+        assert!(err.to_string().contains("below minimum"), "got: {err}");
+    }
+
+    #[test]
+    fn test_enforce_min_tcb_fmc_required_but_absent_rejected() {
+        let report = parse_report(LIVE_REPORT_V5).unwrap();
+        let tcb = &report.reported_tcb;
+        assert!(tcb.fmc.is_none(), "Genoa reports carry no FMC");
+        let floor = SnpTcb {
+            bootloader: 0,
+            tee: 0,
+            snp: 0,
+            microcode: 0,
+            fmc: Some(1),
+        };
+        enforce_min_tcb(tcb, &floor)
+            .expect_err("a floor requiring FMC must reject a report without it");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes the attestation-rs half of [confidential-dot-ai/c8s-workspace#162](https://github.com/confidential-dot-ai/c8s-workspace/issues/162).

The browser `verify_snp` export enforced only the ARK→ASK→VCEK chain, report signature, report_data binding, VMPL and debug policy — no VEK validity period, no VEK/report TCB and chip-id cross-validation, no revocation, no TCB floor. It keeps its explicit `generation` argument (v2 HCL-unwrapped reports carry no CPUID to auto-detect from; the VEK chain authenticates the declaration) and now enforces the rest of the native SNP policy.

- `verify_snp`: VEK validity period, VEK chip-id/TCB OID cross-validation, VLEK (ARK→ASVK) support, optional `min_tcb_json` floor (fails closed below it), optional caller-supplied AMD KDS CRL (`crl_der`), and `collateral_verified` in the result. New `verify_vek_endorsement` in `platforms/snp/verify.rs` bundles the chain/validity/TCB checks it shares with the native path.
- `verify_az_snp` and the generic `verify`: same `min_tcb_json` and CRL parameters; the az-snp core (`verify_report`) now also checks the VEK validity period, which it previously skipped on native and wasm alike.
- `check_vcek_not_revoked`: rejects stale (past `nextUpdate`), future-dated, and `nextUpdate`-less CRLs, so a genuine but outdated list cannot vouch for a since-revoked VEK. Caller-supplied CRL bytes need no transport trust — the ARK signature check and this freshness window authenticate them.
- Negative tests: expired/not-yet-valid VEK, VEK/report TCB mismatch, below-floor TCB (and at-floor pass), revoked serial, stale/future/forged CRL (rcgen-minted issuer), malformed `min_tcb`, garbage CRL through both wasm entry points.

The consumer-side policy surface (minTcb / snpCrl / requireCollateral in c8s-verify-js) lands in a follow-up PR that bumps its `vendor/attestation-rs` pin to this change.