### PR TITLE
feat(certs): keep VCEKs and AMD chains on disk so a cold process survives a KDS outage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "subtle",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml",

--- a/crates/attestation-api/Cargo.toml
+++ b/crates/attestation-api/Cargo.toml
@@ -65,6 +65,9 @@ uuid = { workspace = true, features = ["v4"] }
 rand = { workspace = true }
 hex = { workspace = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [[bin]]
 name = "loadtest"
 path = "src/bin/loadtest.rs"

--- a/crates/attestation-api/src/certs/cache.rs
+++ b/crates/attestation-api/src/certs/cache.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use tokio::sync::RwLock;
 
 use crate::certs::hours_to_duration;
+use crate::certs::store::CollateralStore;
 use crate::config::{normalize_generation, CertsConfig, KNOWN_GENERATIONS};
 
 /// Key for VCEK cache: (processor_gen, chip_id_hex, tcb_version)
@@ -44,10 +45,21 @@ pub struct CertCache {
     crl_refresh_hours: u64,
     crl_backoff_base_secs: u64,
     crl_backoff_max_secs: u64,
+    /// Disk-backed VCEK/chain store. `None` keeps collateral in memory only.
+    store: Option<CollateralStore>,
 }
 
 impl CertCache {
     pub fn new(config: &CertsConfig) -> Self {
+        let http_client = Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("failed to build HTTP client");
+        Self::with_client(config, http_client)
+    }
+
+    pub(crate) fn with_client(config: &CertsConfig, http_client: Client) -> Self {
         let vcek_cache = Cache::builder()
             .max_capacity(config.cache_max_entries)
             .time_to_live(hours_to_duration(config.vcek_ttl_hours))
@@ -112,15 +124,16 @@ impl CertCache {
             crl_failure_cache,
             jwks_cache,
             last_crl_refresh: Arc::new(RwLock::new(None)),
-            http_client: Client::builder()
-                .connect_timeout(Duration::from_secs(10))
-                .timeout(Duration::from_secs(30))
-                .build()
-                .expect("failed to build HTTP client"),
+            http_client,
             configured_generations,
             crl_refresh_hours: config.crl_refresh_hours,
             crl_backoff_base_secs,
             crl_backoff_max_secs: config.crl_backoff_max_secs,
+            store: config
+                .local_collateral_dir
+                .as_ref()
+                .filter(|d| !d.is_empty())
+                .map(CollateralStore::new),
         }
     }
 
@@ -152,6 +165,15 @@ impl CertCache {
             return Ok(cert);
         }
 
+        // A VCEK never changes for this key, so a stored copy is authoritative
+        // and lets a cold process verify while KDS is unreachable.
+        if let Some(store) = &self.store {
+            if let Some(cert) = store.get_vcek(processor_gen, &chip_id_hex, &tcb_str) {
+                self.vcek_cache.insert(key, cert.clone()).await;
+                return Ok(cert);
+            }
+        }
+
         let url = format!(
             "{}/{}/{}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
             attestation::AMD_KDS_VCEK_BASE,
@@ -166,6 +188,9 @@ impl CertCache {
         tracing::info!(%url, "fetching VCEK from AMD KDS");
         let resp = self.http_client.get(&url).send().await?;
         let cert = resp.error_for_status()?.bytes().await?.to_vec();
+        if let Some(store) = &self.store {
+            store.put_vcek(processor_gen, &chip_id_hex, &tcb_str, &cert);
+        }
         self.vcek_cache.insert(key, cert.clone()).await;
         Ok(cert)
     }
@@ -173,6 +198,15 @@ impl CertCache {
     pub async fn get_cert_chain(&self, processor_gen: &str) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
         if let Some(chain) = self.chain_cache.get(processor_gen).await {
             return Ok(chain);
+        }
+
+        if let Some(store) = &self.store {
+            if let Some(chain) = store.get_chain(processor_gen) {
+                self.chain_cache
+                    .insert(processor_gen.to_string(), chain.clone())
+                    .await;
+                return Ok(chain);
+            }
         }
 
         let url = format!(
@@ -187,6 +221,9 @@ impl CertCache {
 
         // The cert chain PEM contains two certificates: ASK then ARK
         let chain = parse_cert_chain_pem(&pem_data)?;
+        if let Some(store) = &self.store {
+            store.put_chain(processor_gen, &chain.0, &chain.1);
+        }
         self.chain_cache
             .insert(processor_gen.to_string(), chain.clone())
             .await;
@@ -468,6 +505,120 @@ pub(crate) fn parse_cert_chain_pem(pem_data: &[u8]) -> anyhow::Result<(Vec<u8>, 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every request is routed through a closed local port, so any code path that
+    /// reaches for the network fails. A call that still succeeds provably did not.
+    fn offline_client() -> Client {
+        Client::builder()
+            .proxy(reqwest::Proxy::all("http://127.0.0.1:1").unwrap())
+            .connect_timeout(Duration::from_secs(2))
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap()
+    }
+
+    fn cfg_with_store(dir: Option<&std::path::Path>) -> CertsConfig {
+        CertsConfig {
+            local_collateral_dir: dir.map(|d| d.to_string_lossy().to_string()),
+            ..Default::default()
+        }
+    }
+
+    const TEST_CHIP: [u8; 64] = [0xAB; 64];
+
+    fn test_tcb() -> attestation::SnpTcb {
+        attestation::SnpTcb {
+            fmc: None,
+            bootloader: 3,
+            tee: 0,
+            snp: 10,
+            microcode: 27,
+        }
+    }
+
+    #[tokio::test]
+    async fn vcek_is_served_from_the_store_with_no_network() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = CertCache::with_client(&cfg_with_store(Some(dir.path())), offline_client());
+
+        // Seed through the same key derivation the lookup uses.
+        let tcb = test_tcb();
+        let store = crate::certs::store::CollateralStore::new(dir.path());
+        store.put_vcek(
+            "Genoa",
+            &hex::encode(TEST_CHIP),
+            &format!(
+                "{:02X}{:02X}{:02X}{:02X}",
+                tcb.bootloader, tcb.tee, tcb.snp, tcb.microcode
+            ),
+            b"stored-vcek",
+        );
+
+        let cert = cache
+            .get_vcek("Genoa", &TEST_CHIP, &tcb)
+            .await
+            .expect("a stored VCEK must be served while the network is unreachable");
+        assert_eq!(cert, b"stored-vcek");
+    }
+
+    #[tokio::test]
+    async fn vcek_without_a_stored_copy_needs_the_network() {
+        // Control for the test above: same offline client, empty store. If this
+        // ever passes, the network block is not blocking and the test above proves
+        // nothing.
+        let dir = tempfile::tempdir().unwrap();
+        let cache = CertCache::with_client(&cfg_with_store(Some(dir.path())), offline_client());
+        assert!(cache
+            .get_vcek("Genoa", &TEST_CHIP, &test_tcb())
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn a_second_cold_process_reads_the_stored_vcek() {
+        let dir = tempfile::tempdir().unwrap();
+        let tcb = test_tcb();
+        let tcb_str = format!(
+            "{:02X}{:02X}{:02X}{:02X}",
+            tcb.bootloader, tcb.tee, tcb.snp, tcb.microcode
+        );
+
+        // Populate via one cache, then read with a second one that shares only the
+        // directory: that is exactly the cold-process path.
+        let first = CertCache::with_client(&cfg_with_store(Some(dir.path())), offline_client());
+        crate::certs::store::CollateralStore::new(dir.path()).put_vcek(
+            "Genoa",
+            &hex::encode(TEST_CHIP),
+            &tcb_str,
+            b"written-back",
+        );
+        drop(first);
+
+        let second = CertCache::with_client(&cfg_with_store(Some(dir.path())), offline_client());
+        assert_eq!(
+            second.get_vcek("Genoa", &TEST_CHIP, &tcb).await.unwrap(),
+            b"written-back"
+        );
+    }
+
+    #[tokio::test]
+    async fn without_a_configured_directory_nothing_is_persisted() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = CertCache::with_client(&cfg_with_store(None), offline_client());
+        assert!(cache
+            .get_vcek("Genoa", &TEST_CHIP, &test_tcb())
+            .await
+            .is_err());
+        assert_eq!(
+            fs_count(dir.path()),
+            0,
+            "an unset collateral dir must leave the filesystem untouched"
+        );
+    }
+
+    fn fs_count(p: &std::path::Path) -> usize {
+        std::fs::read_dir(p).map(|d| d.count()).unwrap_or(0)
+    }
 
     // Minimal PEM with valid base64 body (content is arbitrary, just needs to decode)
     const FAKE_CERT: &str = "-----BEGIN CERTIFICATE-----\naGVsbG8=\n-----END CERTIFICATE-----\n";

--- a/crates/attestation-api/src/certs/mod.rs
+++ b/crates/attestation-api/src/certs/mod.rs
@@ -3,6 +3,7 @@ pub mod manager;
 pub mod nras_provider;
 pub mod revocation;
 pub mod snp_provider;
+pub mod store;
 pub mod tdx_provider;
 
 use std::time::Duration;

--- a/crates/attestation-api/src/certs/store.rs
+++ b/crates/attestation-api/src/certs/store.rs
@@ -1,0 +1,222 @@
+//! Durable collateral store.
+//!
+//! A VCEK is fixed for a (generation, chip, TCB) triple and an AMD cert chain is
+//! fixed per generation, so both are safe to keep on disk indefinitely. Doing so
+//! is what lets attestation survive a cold process or a KDS outage. CRLs are
+//! deliberately absent: serving a stale CRL silently weakens revocation.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::config::normalize_generation;
+
+static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+pub struct CollateralStore {
+    root: PathBuf,
+}
+
+impl CollateralStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn get_vcek(&self, processor_gen: &str, chip_id_hex: &str, tcb: &str) -> Option<Vec<u8>> {
+        read_if_present(&self.vcek_path(processor_gen, chip_id_hex, tcb)?)
+    }
+
+    pub fn put_vcek(&self, processor_gen: &str, chip_id_hex: &str, tcb: &str, der: &[u8]) {
+        let Some(path) = self.vcek_path(processor_gen, chip_id_hex, tcb) else {
+            return;
+        };
+        write_atomic(&path, der);
+    }
+
+    /// Both halves must be present; a chain missing one file is treated as absent
+    /// so a torn write can never yield a half-chain.
+    pub fn get_chain(&self, processor_gen: &str) -> Option<(Vec<u8>, Vec<u8>)> {
+        let dir = self.chain_dir(processor_gen)?;
+        let ark = read_if_present(&dir.join("ark.der"))?;
+        let ask = read_if_present(&dir.join("ask.der"))?;
+        Some((ark, ask))
+    }
+
+    pub fn put_chain(&self, processor_gen: &str, ark_der: &[u8], ask_der: &[u8]) {
+        let Some(dir) = self.chain_dir(processor_gen) else {
+            return;
+        };
+        write_atomic(&dir.join("ark.der"), ark_der);
+        write_atomic(&dir.join("ask.der"), ask_der);
+    }
+
+    /// Every path component is either a member of the fixed generation list or
+    /// hex, so a caller cannot walk out of the store root.
+    fn vcek_path(&self, processor_gen: &str, chip_id_hex: &str, tcb: &str) -> Option<PathBuf> {
+        let generation = normalize_generation(processor_gen)?;
+        if !is_hex(chip_id_hex) || !is_hex(tcb) {
+            tracing::warn!(chip_id_hex, tcb, "refusing non-hex VCEK store key");
+            return None;
+        }
+        Some(
+            self.root
+                .join("vcek")
+                .join(generation)
+                .join(format!("{chip_id_hex}-{tcb}.der")),
+        )
+    }
+
+    fn chain_dir(&self, processor_gen: &str) -> Option<PathBuf> {
+        Some(
+            self.root
+                .join("chain")
+                .join(normalize_generation(processor_gen)?),
+        )
+    }
+}
+
+fn is_hex(s: &str) -> bool {
+    !s.is_empty() && s.len() <= 256 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+fn read_if_present(path: &Path) -> Option<Vec<u8>> {
+    match fs::read(path) {
+        Ok(bytes) if bytes.is_empty() => None,
+        Ok(bytes) => Some(bytes),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "collateral store read failed");
+            None
+        }
+    }
+}
+
+/// Temp file plus rename, so a concurrent reader never observes a partial cert.
+/// Failures are logged and swallowed: the store is a cache and must never be the
+/// reason a verification fails.
+fn write_atomic(path: &Path, bytes: &[u8]) {
+    let Some(dir) = path.parent() else { return };
+    if let Err(e) = fs::create_dir_all(dir) {
+        tracing::warn!(path = %dir.display(), error = %e, "collateral store mkdir failed");
+        return;
+    }
+
+    let seq = TMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let tmp = dir.join(format!(".tmp.{}.{seq}", std::process::id()));
+
+    let written = fs::File::create(&tmp).and_then(|mut f| {
+        f.write_all(bytes)?;
+        f.sync_all()
+    });
+    if let Err(e) = written {
+        tracing::warn!(path = %tmp.display(), error = %e, "collateral store write failed");
+        let _ = fs::remove_file(&tmp);
+        return;
+    }
+
+    if let Err(e) = fs::rename(&tmp, path) {
+        tracing::warn!(path = %path.display(), error = %e, "collateral store rename failed");
+        let _ = fs::remove_file(&tmp);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> (tempfile::TempDir, CollateralStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = CollateralStore::new(dir.path());
+        (dir, store)
+    }
+
+    const CHIP: &str = "ab12cd34";
+    const TCB: &str = "03000A1B";
+
+    #[test]
+    fn vcek_round_trips() {
+        let (_dir, store) = store();
+        store.put_vcek("Genoa", CHIP, TCB, b"der-bytes");
+        assert_eq!(store.get_vcek("Genoa", CHIP, TCB).unwrap(), b"der-bytes");
+    }
+
+    #[test]
+    fn vcek_is_keyed_by_generation_chip_and_tcb() {
+        let (_dir, store) = store();
+        store.put_vcek("Genoa", CHIP, TCB, b"genoa");
+        assert!(store.get_vcek("Milan", CHIP, TCB).is_none());
+        assert!(store.get_vcek("Genoa", "ffffffff", TCB).is_none());
+        assert!(store.get_vcek("Genoa", CHIP, "04000A1B").is_none());
+    }
+
+    #[test]
+    fn unknown_generation_touches_no_files() {
+        let (dir, store) = store();
+        store.put_vcek("Bogus", CHIP, TCB, b"nope");
+        assert!(store.get_vcek("Bogus", CHIP, TCB).is_none());
+        assert!(
+            !dir.path().join("vcek").exists(),
+            "an unknown generation must not create anything under the store root"
+        );
+    }
+
+    #[test]
+    fn traversal_keys_are_refused_and_write_nothing() {
+        let (dir, store) = store();
+        for bad in ["../../etc/passwd", "..", "ab/cd", "ab12cd34 "] {
+            store.put_vcek("Genoa", bad, TCB, b"nope");
+            assert!(store.get_vcek("Genoa", bad, TCB).is_none(), "{bad}");
+        }
+        // Nothing may exist outside the Genoa VCEK directory, and that directory
+        // must not have been created either.
+        assert!(!dir.path().join("vcek").exists());
+    }
+
+    #[test]
+    fn half_written_chain_reads_as_absent() {
+        let (dir, store) = store();
+        let gen_dir = dir.path().join("chain").join("Genoa");
+        fs::create_dir_all(&gen_dir).unwrap();
+        fs::write(gen_dir.join("ark.der"), b"ark").unwrap();
+        assert!(
+            store.get_chain("Genoa").is_none(),
+            "a chain missing its ASK half must not be served"
+        );
+
+        store.put_chain("Genoa", b"ark", b"ask");
+        assert_eq!(
+            store.get_chain("Genoa").unwrap(),
+            (b"ark".to_vec(), b"ask".to_vec())
+        );
+    }
+
+    #[test]
+    fn empty_file_reads_as_absent() {
+        let (dir, store) = store();
+        let p = dir.path().join("vcek").join("Genoa");
+        fs::create_dir_all(&p).unwrap();
+        fs::write(p.join(format!("{CHIP}-{TCB}.der")), b"").unwrap();
+        assert!(store.get_vcek("Genoa", CHIP, TCB).is_none());
+    }
+
+    #[test]
+    fn write_leaves_no_temp_files_behind() {
+        let (dir, store) = store();
+        store.put_vcek("Genoa", CHIP, TCB, b"der");
+        let leftovers: Vec<_> = fs::read_dir(dir.path().join("vcek").join("Genoa"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|n| n.starts_with(".tmp."))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "temp files left behind: {leftovers:?}"
+        );
+    }
+}

--- a/crates/attestation-api/src/config.rs
+++ b/crates/attestation-api/src/config.rs
@@ -114,6 +114,9 @@ pub struct CertsConfig {
     pub crl_backoff_base_secs: u64,
     /// Ceiling for the CRL failure backoff, in seconds.
     pub crl_backoff_max_secs: u64,
+    /// Directory holding VCEKs and AMD cert chains across restarts. Unset keeps
+    /// collateral in memory only, so a cold process must reach AMD KDS.
+    pub local_collateral_dir: Option<String>,
 
     // --- NVIDIA NRAS / GPU attestation ---
     /// TTL for cached NRAS JWKS entries (hours).
@@ -177,6 +180,7 @@ impl Default for CertsConfig {
             require_crl: false,
             crl_backoff_base_secs: 1,
             crl_backoff_max_secs: 300,
+            local_collateral_dir: None,
             jwks_ttl_hours: 1,
             prefetch_nras_jwks: true,
             nras_gpu_url: String::new(),


### PR DESCRIPTION
attestation-api keeps VCEKs and AMD cert chains in an in-process moka cache, so a cold process must reach AMD KDS before it can verify anything. On 2026-08-31 KDS refused connections for several hours and snp-metal went red on it. The lane builds a fresh cluster per run, so the attestation-api pod starts with an empty cache every time and had nothing to fall back on:

```
API error (502): certificate fetch failed: cached VCEK fetch:
error sending request for url (https://kdsintf.amd.com/vcek/v1/Genoa/9277b37a...)
```

This adds an optional on-disk store under `certs.local_collateral_dir`, read after the memory cache and written after a successful fetch. A VCEK is fixed for a (generation, chip, TCB) triple and a chain is fixed per generation, so a stored copy is authoritative and safe to keep indefinitely. Unset by default, so nothing changes until an operator points it at a directory.

**CRLs are deliberately not stored.** A stale CRL silently weakens revocation, and it is the one artifact here with real freshness semantics. `require_crl` remains the knob for that.

Path safety: the generation component comes from `normalize_generation` (fixed list) and the rest must be hex, so a caller cannot walk out of the store root. Writes go to a temp file and rename, so a reader never sees a partial cert. Every store error is logged and swallowed; the store is a cache and must never be why a verification fails.

Tests assert behaviour, not messages. The load-bearing one routes the HTTP client through a closed local port so any code path touching the network fails, then shows a seeded VCEK still being served. Its control asserts the same call fails with an empty store, so a false pass would mean the network block is not blocking:

```
vcek_is_served_from_the_store_with_no_network ... ok
vcek_without_a_stored_copy_needs_the_network ... ok
a_second_cold_process_reads_the_stored_vcek ... ok
without_a_configured_directory_nothing_is_persisted ... ok
traversal_keys_are_refused_and_write_nothing ... ok
half_written_chain_reads_as_absent ... ok
```

53 pass, clippy clean under `-D warnings`, fmt clean.

Not covered: the write-back line inside `get_vcek` has no test. `AMD_KDS_VCEK_BASE` is a const with no injection point, so there is no way to stand up a fake KDS and observe a real fetch landing on disk. The store's own put/get is tested directly, but the wiring between them is unverified. Nothing prunes the directory either, so it grows one small file per TCB revision.

This is half the fix. It lets a pod survive a restart, and it does nothing for a genuinely cold host, because the first run still has to reach KDS. Seeding the directory on the SNP metal host is the follow-up, and it is the piece that mirrors what pccsd does on the Intel side.
