### PR TITLE
feat(api): enrich chainless bare-SNP /attest evidence with the cached VCEK

### DIFF
--- a/crates/attestation-api/Cargo.toml
+++ b/crates/attestation-api/Cargo.toml
@@ -67,6 +67,7 @@ hex = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["full", "test-util"] }
 
 [[bin]]
 name = "loadtest"

--- a/crates/attestation-api/src/api/attest.rs
+++ b/crates/attestation-api/src/api/attest.rs
@@ -85,9 +85,22 @@ pub async fn handler(
         // Keep the service response shape stable: top-level `platform` plus
         // platform-specific `evidence` (+ optional `nvidia_gpu`). /verify
         // accepts this split form when clients send the same fields.
+        let mut evidence = envelope.get("evidence").cloned().unwrap_or(envelope);
+
+        // Bare-metal hypervisors may leave the cert table empty; fill in the
+        // VCEK from the service cert cache so offline verifiers get a chain.
+        if matches!(platform, attestation::PlatformType::Snp) {
+            let provider =
+                std::sync::Arc::new(crate::certs::snp_provider::CachedCertProvider::new(
+                    state.cert_cache.clone(),
+                    state.config.certs.require_crl,
+                ));
+            evidence = crate::certs::enrich::enrich_snp_evidence(provider, evidence).await;
+        }
+
         Ok(Json(AttestResponse {
             platform: format!("{platform}"),
-            evidence: envelope.get("evidence").cloned().unwrap_or(envelope),
+            evidence,
             nvidia_gpu: gpu_field,
         }))
     }

--- a/crates/attestation-api/src/certs/cache.rs
+++ b/crates/attestation-api/src/certs/cache.rs
@@ -161,38 +161,40 @@ impl CertCache {
             tcb_str.clone(),
         );
 
-        if let Some(cert) = self.vcek_cache.get(&key).await {
-            return Ok(cert);
-        }
+        // try_get_with coalesces concurrent misses into one disk probe and
+        // (on a store miss) one KDS fetch
+        // (AMD rate-limits VCEK fetches to ~1 per 10s per IP).
+        self.vcek_cache
+            .try_get_with(key, async move {
+                // A VCEK never changes for this key, so a stored copy is
+                // authoritative and lets a cold process verify while KDS is
+                // unreachable.
+                if let Some(store) = &self.store {
+                    if let Some(cert) = store.get_vcek(processor_gen, &chip_id_hex, &tcb_str) {
+                        return anyhow::Ok(cert);
+                    }
+                }
 
-        // A VCEK never changes for this key, so a stored copy is authoritative
-        // and lets a cold process verify while KDS is unreachable.
-        if let Some(store) = &self.store {
-            if let Some(cert) = store.get_vcek(processor_gen, &chip_id_hex, &tcb_str) {
-                self.vcek_cache.insert(key, cert.clone()).await;
-                return Ok(cert);
-            }
-        }
-
-        let url = format!(
-            "{}/{}/{}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
-            attestation::AMD_KDS_VCEK_BASE,
-            processor_gen,
-            chip_id_hex,
-            tcb.bootloader,
-            tcb.tee,
-            tcb.snp,
-            tcb.microcode
-        );
-
-        tracing::info!(%url, "fetching VCEK from AMD KDS");
-        let resp = self.http_client.get(&url).send().await?;
-        let cert = resp.error_for_status()?.bytes().await?.to_vec();
-        if let Some(store) = &self.store {
-            store.put_vcek(processor_gen, &chip_id_hex, &tcb_str, &cert);
-        }
-        self.vcek_cache.insert(key, cert.clone()).await;
-        Ok(cert)
+                let url = format!(
+                    "{}/{}/{}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
+                    attestation::AMD_KDS_VCEK_BASE,
+                    processor_gen,
+                    chip_id_hex,
+                    tcb.bootloader,
+                    tcb.tee,
+                    tcb.snp,
+                    tcb.microcode
+                );
+                tracing::info!(%url, "fetching VCEK from AMD KDS");
+                let resp = self.http_client.get(&url).send().await?;
+                let cert = resp.error_for_status()?.bytes().await?.to_vec();
+                if let Some(store) = &self.store {
+                    store.put_vcek(processor_gen, &chip_id_hex, &tcb_str, &cert);
+                }
+                anyhow::Ok(cert)
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!("VCEK fetch: {e}"))
     }
 
     pub async fn get_cert_chain(&self, processor_gen: &str) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {

--- a/crates/attestation-api/src/certs/enrich.rs
+++ b/crates/attestation-api/src/certs/enrich.rs
@@ -1,0 +1,378 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::time::timeout;
+
+use attestation::platforms::snp::certs::get_bundled_certs;
+use attestation::platforms::snp::evidence::{SnpCertChain, SnpEvidence};
+use attestation::platforms::snp::verify::{parse_report, verify_cert_chain};
+use attestation::{CertProvider, ProcessorGeneration, SnpTcb};
+
+/// Bound on the VCEK lookup as seen by the request; a timed-out fetch keeps
+/// running detached so it can still warm the cache for the next request.
+const VCEK_LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Embed `cert_chain.vcek` into chainless bare-SNP evidence via the given
+/// cert provider, so offline verifiers get the chain without their own KDS
+/// fetch. Returns the evidence unchanged when a chain is already present or
+/// the VCEK cannot be resolved within [`VCEK_LOOKUP_TIMEOUT`] — enrichment
+/// never fails the request.
+pub async fn enrich_snp_evidence(provider: Arc<dyn CertProvider>, evidence: Value) -> Value {
+    let snp = match SnpEvidence::deserialize(&evidence) {
+        Ok(snp) => snp,
+        Err(e) => {
+            // /attest produced this evidence in-process, so a shape mismatch
+            // is a bug in this binary, not an input condition.
+            tracing::error!(error = %e, "SNP evidence does not round-trip; skipping VCEK enrichment");
+            return evidence;
+        }
+    };
+    if snp.cert_chain.is_some() {
+        return evidence;
+    }
+
+    let (gen, chip_id, tcb) = match vcek_identity(&snp.attestation_report) {
+        Ok(identity) => identity,
+        Err(reason) => {
+            tracing::warn!(
+                reason,
+                "cannot derive VCEK identity from SNP report; serving chainless evidence"
+            );
+            return evidence;
+        }
+    };
+
+    let lookup = tokio::spawn(async move { provider.get_snp_vcek(gen, &chip_id, &tcb).await });
+    let vcek_der = match timeout(VCEK_LOOKUP_TIMEOUT, lookup).await {
+        Ok(Ok(Ok(vcek_der))) => vcek_der,
+        Ok(Ok(Err(e))) => {
+            tracing::warn!(error = %e, "VCEK unavailable; serving chainless evidence");
+            return evidence;
+        }
+        Ok(Err(e)) => {
+            tracing::error!(error = %e, "VCEK lookup task failed; serving chainless evidence");
+            return evidence;
+        }
+        Err(_) => {
+            tracing::warn!(
+                timeout_secs = VCEK_LOOKUP_TIMEOUT.as_secs(),
+                "VCEK lookup timed out; serving chainless evidence"
+            );
+            return evidence;
+        }
+    };
+
+    // Embedded certs bypass the verifier's own KDS fallback, so never embed
+    // bytes that don't chain to the bundled AMD anchors.
+    let (ark, ask) = get_bundled_certs(gen);
+    if let Err(e) = verify_cert_chain(ark, ask, &vcek_der) {
+        tracing::warn!(error = %e, "resolved VCEK fails AMD chain validation; serving chainless evidence");
+        return evidence;
+    }
+
+    let enriched = SnpEvidence {
+        attestation_report: snp.attestation_report,
+        cert_chain: Some(SnpCertChain {
+            vcek: BASE64.encode(vcek_der),
+            ask: None,
+            ark: None,
+        }),
+    };
+    serde_json::to_value(&enriched).unwrap_or(evidence)
+}
+
+/// Derive the KDS lookup identity (generation, chip_id, reported TCB) from a
+/// base64-encoded SNP report. Mirrors attestation-rs snp::verify::resolve_vcek.
+fn vcek_identity(report_b64: &str) -> Result<(ProcessorGeneration, [u8; 64], SnpTcb), String> {
+    let report_bytes = BASE64
+        .decode(report_b64)
+        .map_err(|e| format!("attestation_report base64: {e}"))?;
+    let report = parse_report(&report_bytes).map_err(|e| format!("report parse: {e}"))?;
+
+    if report.chip_id.iter().all(|&b| b == 0) {
+        return Err(
+            "chip_id is all zeros (MASK_CHIP_ID set); VCEK cannot be looked up".to_string(),
+        );
+    }
+
+    let (Some(fam), Some(model)) = (report.cpuid_fam_id, report.cpuid_mod_id) else {
+        return Err(format!(
+            "report v{} lacks CPUID family/model fields",
+            report.version
+        ));
+    };
+    let gen = ProcessorGeneration::from_cpuid(fam, model)
+        .ok_or_else(|| format!("unknown processor: family=0x{fam:02X}, model=0x{model:02X}"))?;
+
+    let tcb = SnpTcb {
+        bootloader: report.reported_tcb.bootloader,
+        tee: report.reported_tcb.tee,
+        snp: report.reported_tcb.snp,
+        microcode: report.reported_tcb.microcode,
+        fmc: if gen == ProcessorGeneration::Turin {
+            report.reported_tcb.fmc
+        } else {
+            None
+        },
+    };
+    let mut chip_id = [0u8; 64];
+    chip_id.copy_from_slice(&report.chip_id[..]);
+    Ok((gen, chip_id, tcb))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    // Real report/VCEK pair from lunal-dev/attestation-rs test_data (Apache-2.0).
+    const REPORT_V5_GENOA: &[u8] =
+        include_bytes!("../../../attestation/test_data/snp/live-report-v5-genoa.bin");
+    const VCEK_GENOA: &[u8] =
+        include_bytes!("../../../attestation/test_data/snp/live-vcek-genoa.der");
+    const REPORT_V2_MILAN: &[u8] =
+        include_bytes!("../../../attestation/test_data/snp/test-report.bin");
+
+    // Identity of REPORT_V5_GENOA, spelled literally so derivation drift fails loudly.
+    const V5_CHIP_ID_HEX: &str = "b5f9a4c8280e63c97d288db6648577dc2b848884aa682d7a227ba40e50deb2b0\
+d112b599d87aaccda78d06f4254b1e81c4d953ef3c699db39d4e06013e9fa4ce";
+    const V5_TCB: SnpTcb = SnpTcb {
+        bootloader: 0x0A,
+        tee: 0x00,
+        snp: 0x1B,
+        microcode: 0x1B,
+        fmc: None,
+    };
+
+    /// Stub provider: records the lookup arguments and serves a fixed response.
+    struct StubProvider {
+        response: Result<Vec<u8>, String>,
+        calls: Mutex<Vec<(ProcessorGeneration, [u8; 64], SnpTcb)>>,
+    }
+
+    impl StubProvider {
+        fn ok(vcek_der: &[u8]) -> Arc<Self> {
+            Arc::new(Self {
+                response: Ok(vcek_der.to_vec()),
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn err(message: &str) -> Arc<Self> {
+            Arc::new(Self {
+                response: Err(message.to_string()),
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CertProvider for StubProvider {
+        async fn get_snp_vcek(
+            &self,
+            gen: ProcessorGeneration,
+            chip_id: &[u8; 64],
+            tcb: &SnpTcb,
+        ) -> attestation::Result<Vec<u8>> {
+            self.calls.lock().unwrap().push((gen, *chip_id, *tcb));
+            self.response
+                .clone()
+                .map_err(attestation::AttestationError::CertFetchError)
+        }
+
+        async fn get_snp_cert_chain(
+            &self,
+            _gen: ProcessorGeneration,
+        ) -> attestation::Result<(Vec<u8>, Vec<u8>)> {
+            unreachable!("enrichment never fetches the ARK/ASK chain")
+        }
+    }
+
+    /// Provider with no network: every fetch errors (for the verifier round-trip).
+    struct OfflineProvider;
+
+    #[async_trait::async_trait]
+    impl CertProvider for OfflineProvider {
+        async fn get_snp_vcek(
+            &self,
+            _gen: ProcessorGeneration,
+            _chip_id: &[u8; 64],
+            _tcb: &SnpTcb,
+        ) -> attestation::Result<Vec<u8>> {
+            Err(attestation::AttestationError::CertFetchError(
+                "offline".to_string(),
+            ))
+        }
+
+        async fn get_snp_cert_chain(
+            &self,
+            _gen: ProcessorGeneration,
+        ) -> attestation::Result<(Vec<u8>, Vec<u8>)> {
+            Err(attestation::AttestationError::CertFetchError(
+                "offline".to_string(),
+            ))
+        }
+    }
+
+    /// Provider whose lookup never resolves (for the timeout arm).
+    struct HangingProvider;
+
+    #[async_trait::async_trait]
+    impl CertProvider for HangingProvider {
+        async fn get_snp_vcek(
+            &self,
+            _gen: ProcessorGeneration,
+            _chip_id: &[u8; 64],
+            _tcb: &SnpTcb,
+        ) -> attestation::Result<Vec<u8>> {
+            std::future::pending().await
+        }
+
+        async fn get_snp_cert_chain(
+            &self,
+            _gen: ProcessorGeneration,
+        ) -> attestation::Result<(Vec<u8>, Vec<u8>)> {
+            unreachable!("enrichment never fetches the ARK/ASK chain")
+        }
+    }
+
+    fn chainless_evidence(report: &[u8]) -> Value {
+        json!({
+            "attestation_report": BASE64.encode(report),
+            "cert_chain": null,
+        })
+    }
+
+    #[test]
+    fn vcek_identity_extracts_report_fields() {
+        let (gen, chip_id, tcb) = vcek_identity(&BASE64.encode(REPORT_V5_GENOA)).unwrap();
+        assert_eq!(gen, ProcessorGeneration::Genoa);
+        assert_eq!(hex::encode(chip_id), V5_CHIP_ID_HEX);
+        assert_eq!(tcb, V5_TCB);
+    }
+
+    #[tokio::test]
+    async fn enriches_chainless_evidence_and_result_verifies() {
+        let provider = StubProvider::ok(VCEK_GENOA);
+        let enriched =
+            enrich_snp_evidence(provider.clone(), chainless_evidence(REPORT_V5_GENOA)).await;
+
+        // The lookup used the report's own identity.
+        {
+            let calls = provider.calls.lock().unwrap();
+            assert_eq!(calls.len(), 1);
+            let (gen, chip_id, tcb) = &calls[0];
+            assert_eq!(*gen, ProcessorGeneration::Genoa);
+            assert_eq!(hex::encode(chip_id), V5_CHIP_ID_HEX);
+            assert_eq!(*tcb, V5_TCB);
+        }
+
+        assert_eq!(
+            enriched["cert_chain"]["vcek"],
+            json!(BASE64.encode(VCEK_GENOA))
+        );
+        assert_eq!(
+            enriched["attestation_report"],
+            json!(BASE64.encode(REPORT_V5_GENOA))
+        );
+
+        // End to end: the enriched evidence verifies offline — the verifier's
+        // provider errors, so the chain can only come from the evidence.
+        let envelope = json!({ "platform": "snp", "evidence": enriched });
+        let verifier = attestation::Verifier::new().with_cert_provider(OfflineProvider);
+        let result = verifier
+            .verify(
+                &serde_json::to_vec(&envelope).unwrap(),
+                &attestation::VerifyParams::default(),
+            )
+            .await
+            .expect("enriched evidence must verify offline");
+        assert!(result.signature_valid);
+    }
+
+    #[tokio::test]
+    async fn keeps_existing_cert_chain() {
+        let provider = StubProvider::ok(VCEK_GENOA);
+        let evidence = json!({
+            "attestation_report": BASE64.encode(REPORT_V5_GENOA),
+            "cert_chain": { "vcek": "aHlwZXJ2aXNvcg==" },
+        });
+        let result = enrich_snp_evidence(provider.clone(), evidence.clone()).await;
+        assert_eq!(result, evidence);
+        assert!(provider.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn serves_chainless_when_chip_id_masked() {
+        // chip_id lives at 0x1A0..0x1E0 in the SNP report.
+        let mut masked = REPORT_V5_GENOA.to_vec();
+        masked[0x1A0..0x1E0].fill(0);
+        let err = vcek_identity(&BASE64.encode(&masked)).unwrap_err();
+        assert!(err.contains("chip_id"), "unexpected error: {err}");
+
+        let provider = StubProvider::ok(VCEK_GENOA);
+        let evidence = chainless_evidence(&masked);
+        let result = enrich_snp_evidence(provider.clone(), evidence.clone()).await;
+        assert_eq!(result, evidence);
+        assert!(provider.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn serves_chainless_for_v2_report_without_cpuid() {
+        let err = vcek_identity(&BASE64.encode(REPORT_V2_MILAN)).unwrap_err();
+        assert!(
+            err.contains("CPUID") || err.contains("unknown processor"),
+            "unexpected error: {err}"
+        );
+
+        let provider = StubProvider::ok(VCEK_GENOA);
+        let evidence = chainless_evidence(REPORT_V2_MILAN);
+        let result = enrich_snp_evidence(provider.clone(), evidence.clone()).await;
+        assert_eq!(result, evidence);
+        assert!(provider.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn serves_unrecognized_evidence_unchanged() {
+        let mut with_extra_field = chainless_evidence(REPORT_V5_GENOA);
+        with_extra_field["unexpected"] = json!(true);
+        for evidence in [
+            json!({ "attestation_report": "!!not-base64" }),
+            json!("not an object"),
+            with_extra_field,
+        ] {
+            let provider = StubProvider::ok(VCEK_GENOA);
+            let result = enrich_snp_evidence(provider.clone(), evidence.clone()).await;
+            assert_eq!(result, evidence);
+            assert!(provider.calls.lock().unwrap().is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn serves_chainless_when_lookup_fails() {
+        let provider = StubProvider::err("KDS unreachable");
+        let evidence = chainless_evidence(REPORT_V5_GENOA);
+        let result = enrich_snp_evidence(provider, evidence.clone()).await;
+        assert_eq!(result, evidence);
+    }
+
+    #[tokio::test]
+    async fn rejects_vcek_that_fails_chain_validation() {
+        let provider = StubProvider::ok(b"not a certificate");
+        let evidence = chainless_evidence(REPORT_V5_GENOA);
+        let result = enrich_snp_evidence(provider, evidence.clone()).await;
+        assert_eq!(result, evidence);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn serves_chainless_on_lookup_timeout() {
+        let evidence = chainless_evidence(REPORT_V5_GENOA);
+        let result = enrich_snp_evidence(Arc::new(HangingProvider), evidence.clone()).await;
+        assert_eq!(result, evidence);
+    }
+}

--- a/crates/attestation-api/src/certs/mod.rs
+++ b/crates/attestation-api/src/certs/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod enrich;
 pub mod manager;
 pub mod nras_provider;
 pub mod revocation;

--- a/crates/attestation-api/tests/kds_live.rs
+++ b/crates/attestation-api/tests/kds_live.rs
@@ -1,0 +1,47 @@
+//! Manual smoke test against live AMD KDS. Run on demand:
+//! `LOCAL_EVIDENCE=<chainless bare-SNP evidence envelope JSON> cargo test --test kds_live -- --ignored --nocapture`
+
+use std::sync::Arc;
+
+use attestation_api::certs::cache::CertCache;
+use attestation_api::certs::enrich::enrich_snp_evidence;
+use attestation_api::certs::snp_provider::CachedCertProvider;
+use base64::Engine;
+
+#[tokio::test]
+#[ignore = "hits live AMD KDS (rate-limited); needs LOCAL_EVIDENCE"]
+async fn enriches_real_chainless_evidence_via_kds() {
+    let path = std::env::var("LOCAL_EVIDENCE").expect("set LOCAL_EVIDENCE to an evidence file");
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+    assert_eq!(envelope["platform"], "snp");
+    let evidence = envelope["evidence"].clone();
+    assert!(evidence["cert_chain"].is_null(), "sample must be chainless");
+
+    let cache = Arc::new(CertCache::new(&Default::default()));
+    let provider = Arc::new(CachedCertProvider::new(cache.clone(), false));
+    let enriched = enrich_snp_evidence(provider.clone(), evidence).await;
+
+    let vcek_der = base64::engine::general_purpose::STANDARD
+        .decode(
+            enriched["cert_chain"]["vcek"]
+                .as_str()
+                .expect("enriched evidence must carry cert_chain.vcek"),
+        )
+        .unwrap();
+    println!("fetched VCEK: {} bytes DER", vcek_der.len());
+
+    // KDS returned the right cert: the report signature must verify.
+    let report_bytes = base64::engine::general_purpose::STANDARD
+        .decode(enriched["attestation_report"].as_str().unwrap())
+        .unwrap();
+    attestation::platforms::snp::verify::verify_report_signature(&report_bytes, &vcek_der)
+        .expect("report signature must verify against enriched VCEK");
+
+    // Second call is served from the cache.
+    let evidence2 = envelope["evidence"].clone();
+    let t0 = std::time::Instant::now();
+    let enriched2 = enrich_snp_evidence(provider, evidence2).await;
+    assert_eq!(enriched2, enriched);
+    println!("second enrichment (cache hit) took {:?}", t0.elapsed());
+}


### PR DESCRIPTION
## What

On bare-metal SEV-SNP the hypervisor supplies no cert table, so `/attest` serves evidence with `cert_chain: null` — offline verifiers (attestation-go, c8s-verify-js) fail closed on the missing `cert_chain.vcek`, and online verifiers fall back to per-client AMD KDS fetches that AMD's per-IP rate limit (~1 VCEK per 10s, 429) regularly breaks. az-snp already embeds its IMDS-fetched VCEK; bare SNP was the gap.

`/attest` now fills `cert_chain.vcek` from the service's own KDS-backed VCEK cache, deriving generation/chip_id/TCB from the report it just produced. Best-effort with a 5s bound: any failure (masked chip_id, pre-v3 report, KDS miss, chain-validation failure, timeout) serves chainless evidence exactly as today, and an embedded VCEK must first chain to the bundled AMD anchors — a bad KDS body can only degrade, never ship. az-snp/TDX/gcp responses are byte-identical to before.

Also: `CertCache::get_vcek` coalesces concurrent misses into one KDS fetch; a timed-out fetch keeps running detached to warm the cache. Once deployed, c8s#528's client-side embedder becomes deletable.

## Review notes

- `vcek_identity` mirrors the private `snp::verify::resolve_vcek` derivation — can lift a shared pub helper into the `attestation` crate instead if preferred.
- `gcp-snp` emits the same chainless shape; extending the gate is one line if wanted.
- No negative caching of KDS 429s yet (~10s TTL is the follow-up if pressure shows up); Turin KDS URLs were wrong before this PR and stay unchanged (degrades to chainless).

## Test plan

- [x] `cargo fmt` / `clippy -D warnings` / `cargo test --workspace` (CI-equivalent)
- [x] Offline `Verifier` round-trip of enriched evidence; one test per degrade arm
- [x] `kds_live` (`#[ignore]`) against real KDS + chainless Genoa evidence: fetch, chain-validate, embed, verify; cache hit on second call; cold-cache rerun reproduced the 429 → chainless arm
- [ ] After merge: repin attestation-api digest, confirm bare-SNP `/attest` carries `cert_chain.vcek` on a fresh cluster, delete c8s#528's embedder
